### PR TITLE
Pequeñas correcciones & Realización HandsOn4

### DIFF
--- a/HandsOn/Group15/lodrefine/operationsDatosEstaciones-with-links.json
+++ b/HandsOn/Group15/lodrefine/operationsDatosEstaciones-with-links.json
@@ -5024,5 +5024,849 @@
       ]
     },
     "description": "Save RDF schema skeleton"
+  },
+  {
+    "op": "rdf-extension/save-rdf-schema",
+    "schema": {
+      "prefixes": [
+        {
+          "name": "rdf",
+          "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        {
+          "name": "owl",
+          "uri": "http://www.w3.org/2002/07/owl#"
+        },
+        {
+          "name": "xml",
+          "uri": "http://www.w3.org/XML/1998/namespace#"
+        },
+        {
+          "name": "xsd",
+          "uri": "http://www.w3.org/2001/XMLSchema#"
+        },
+        {
+          "name": "rdfs",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        {
+          "name": "aqm",
+          "uri": "http://www.airQualityMadrid.com/ontology#"
+        }
+      ],
+      "baseUri": "http://www.airQualityMadrid.com/resource/",
+      "rootNodes": [
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "ID_MEDICION",
+          "expression": "\"Measurement/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_medicion",
+              "curie": "aqm:id_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_MEDICION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_estacion",
+              "curie": "aqm:id_estacion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_ESTACION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#contaminante_medido",
+              "curie": "aqm:contaminante_medido",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "CONTAMINANTE",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#tecnica_medicion",
+              "curie": "aqm:tecnica_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "TECNICA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#unidad",
+              "curie": "aqm:unidad",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "UNIDAD",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#fecha",
+              "curie": "aqm:fecha",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "FECHA",
+                "expression": "value",
+                "valueType": "http://www.w3.org/2001/XMLSchema#date",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_1",
+              "curie": "aqm:valor_a_las_1",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H01",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_2",
+              "curie": "aqm:valor_a_las_2",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H02",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_3",
+              "curie": "aqm:valor_a_las_3",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H03",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_4",
+              "curie": "aqm:valor_a_las_4",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H04",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_5",
+              "curie": "aqm:valor_a_las_5",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H05",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_6",
+              "curie": "aqm:valor_a_las_6",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H06",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_7",
+              "curie": "aqm:valor_a_las_7",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H07",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_8",
+              "curie": "aqm:valor_a_las_8",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H08",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_9",
+              "curie": "aqm:valor_a_las_9",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H09",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_10",
+              "curie": "aqm:valor_a_las_10",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H10",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_11",
+              "curie": "aqm:valor_a_las_11",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H11",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_12",
+              "curie": "aqm:valor_a_las_12",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H12",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_13",
+              "curie": "aqm:valor_a_las_13",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H13",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_14",
+              "curie": "aqm:valor_a_las_14",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H14",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_15",
+              "curie": "aqm:valor_a_las_15",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H15",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_16",
+              "curie": "aqm:valor_a_las_16",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H16",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_17",
+              "curie": "aqm:valor_a_las_17",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H17",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_18",
+              "curie": "aqm:valor_a_las_18",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H18",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_19",
+              "curie": "aqm:valor_a_las_19",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H19",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_20",
+              "curie": "aqm:valor_a_las_20",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H20",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_21",
+              "curie": "aqm:valor_a_las_21",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H21",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_22",
+              "curie": "aqm:valor_a_las_22",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H22",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_23",
+              "curie": "aqm:valor_a_las_23",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H23",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_24",
+              "curie": "aqm:valor_a_las_24",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H24",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Measurement",
+              "curie": "aqm:Measurement"
+            }
+          ]
+        },
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "CONTAMINANTE",
+          "expression": "\"Contaminante/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.w3.org/2002/07/owl#sameAs",
+              "curie": "owl:sameAs",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "Chemical Compound",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Contaminante",
+              "curie": "aqm:Contaminante"
+            }
+          ]
+        },
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "TECNICA",
+          "expression": "\"Tecnica/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.w3.org/2002/07/owl#sameAs",
+              "curie": "owl:sameAs",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "Technique",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Tecnica",
+              "curie": "aqm:Tecnica"
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF schema skeleton"
+  },
+  {
+    "op": "rdf-extension/save-rdf-schema",
+    "schema": {
+      "prefixes": [
+        {
+          "name": "rdf",
+          "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        {
+          "name": "owl",
+          "uri": "http://www.w3.org/2002/07/owl#"
+        },
+        {
+          "name": "xml",
+          "uri": "http://www.w3.org/XML/1998/namespace#"
+        },
+        {
+          "name": "xsd",
+          "uri": "http://www.w3.org/2001/XMLSchema#"
+        },
+        {
+          "name": "rdfs",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        {
+          "name": "aqm",
+          "uri": "http://www.airQualityMadrid.com/ontology#"
+        }
+      ],
+      "baseUri": "http://www.airQualityMadrid.com/resource/",
+      "rootNodes": [
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "ID_MEDICION",
+          "expression": "\"Measurement/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_medicion",
+              "curie": "aqm:id_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_MEDICION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_estacion",
+              "curie": "aqm:id_estacion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_ESTACION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#contaminante_medido",
+              "curie": "aqm:contaminante_medido",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "CONTAMINANTE",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#tecnica_medicion",
+              "curie": "aqm:tecnica_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "TECNICA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#unidad",
+              "curie": "aqm:unidad",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "UNIDAD",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#fecha",
+              "curie": "aqm:fecha",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "FECHA",
+                "expression": "value",
+                "valueType": "http://www.w3.org/2001/XMLSchema#date",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_1",
+              "curie": "aqm:valor_a_las_1",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H01",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_2",
+              "curie": "aqm:valor_a_las_2",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H02",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_3",
+              "curie": "aqm:valor_a_las_3",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H03",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_4",
+              "curie": "aqm:valor_a_las_4",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H04",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_5",
+              "curie": "aqm:valor_a_las_5",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H05",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_6",
+              "curie": "aqm:valor_a_las_6",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H06",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_7",
+              "curie": "aqm:valor_a_las_7",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H07",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_8",
+              "curie": "aqm:valor_a_las_8",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H08",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_9",
+              "curie": "aqm:valor_a_las_9",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H09",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_10",
+              "curie": "aqm:valor_a_las_10",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H10",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_11",
+              "curie": "aqm:valor_a_las_11",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H11",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_12",
+              "curie": "aqm:valor_a_las_12",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H12",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_13",
+              "curie": "aqm:valor_a_las_13",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H13",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_14",
+              "curie": "aqm:valor_a_las_14",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H14",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_15",
+              "curie": "aqm:valor_a_las_15",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H15",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_16",
+              "curie": "aqm:valor_a_las_16",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H16",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_17",
+              "curie": "aqm:valor_a_las_17",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H17",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_18",
+              "curie": "aqm:valor_a_las_18",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H18",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_19",
+              "curie": "aqm:valor_a_las_19",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H19",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_20",
+              "curie": "aqm:valor_a_las_20",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H20",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_21",
+              "curie": "aqm:valor_a_las_21",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H21",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_22",
+              "curie": "aqm:valor_a_las_22",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H22",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_23",
+              "curie": "aqm:valor_a_las_23",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H23",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_24",
+              "curie": "aqm:valor_a_las_24",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H24",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Measurement",
+              "curie": "aqm:Measurement"
+            }
+          ]
+        },
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "CONTAMINANTE",
+          "expression": "\"Contaminante/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.w3.org/2002/07/owl#sameAs",
+              "curie": "owl:sameAs",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "Chemical Compound",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Contaminante",
+              "curie": "aqm:Contaminante"
+            }
+          ]
+        },
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "TECNICA",
+          "expression": "\"Tecnica/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.w3.org/2002/07/owl#sameAs",
+              "curie": "owl:sameAs",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "Technique",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Tecnica",
+              "curie": "aqm:Tecnica"
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF schema skeleton"
   }
 ]

--- a/HandsOn/Group15/lodrefine/operationsDatosEstaciones-with-links.json
+++ b/HandsOn/Group15/lodrefine/operationsDatosEstaciones-with-links.json
@@ -1,0 +1,5028 @@
+[
+  {
+    "op": "core/column-removal",
+    "columnName": "PROVINCIA",
+    "description": "Remove column PROVINCIA"
+  },
+  {
+    "op": "core/column-removal",
+    "columnName": "MUNICIPIO",
+    "description": "Remove column MUNICIPIO"
+  },
+  {
+    "op": "core/column-move",
+    "columnName": "PUNTO_MUESTREO",
+    "index": 0,
+    "description": "Move column PUNTO_MUESTREO to position 0"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "DIA",
+    "expression": "grel:value + '-' + cells['MES'].value + '-' + cells['ANIO'].value",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column DIA using expression grel:value + '-' + cells['MES'].value + '-' + cells['ANIO'].value"
+  },
+  {
+    "op": "core/column-removal",
+    "columnName": "ANIO",
+    "description": "Remove column ANIO"
+  },
+  {
+    "op": "core/column-removal",
+    "columnName": "MES",
+    "description": "Remove column MES"
+  },
+  {
+    "op": "core/column-split",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "PUNTO_MUESTREO",
+    "guessCellType": true,
+    "removeOriginalColumn": false,
+    "mode": "separator",
+    "separator": "_",
+    "regex": false,
+    "maxColumns": 0,
+    "description": "Split column PUNTO_MUESTREO by separator"
+  },
+  {
+    "op": "core/column-removal",
+    "columnName": "ESTACION",
+    "description": "Remove column ESTACION"
+  },
+  {
+    "op": "core/column-removal",
+    "columnName": "MAGNITUD",
+    "description": "Remove column MAGNITUD"
+  },
+  {
+    "op": "core/column-rename",
+    "oldColumnName": "PUNTO_MUESTREO",
+    "newColumnName": "ID_MEDICION",
+    "description": "Rename column PUNTO_MUESTREO to ID_MEDICION"
+  },
+  {
+    "op": "core/column-rename",
+    "oldColumnName": "PUNTO_MUESTREO 1",
+    "newColumnName": "ID_ESTACION",
+    "description": "Rename column PUNTO_MUESTREO 1 to ID_ESTACION"
+  },
+  {
+    "op": "core/column-rename",
+    "oldColumnName": "DIA",
+    "newColumnName": "FECHA",
+    "description": "Rename column DIA to FECHA"
+  },
+  {
+    "op": "core/column-rename",
+    "oldColumnName": "PUNTO_MUESTREO 3",
+    "newColumnName": "TECNICA",
+    "description": "Rename column PUNTO_MUESTREO 3 to TECNICA"
+  },
+  {
+    "op": "core/column-rename",
+    "oldColumnName": "PUNTO_MUESTREO 2",
+    "newColumnName": "CONTAMINANTE",
+    "description": "Rename column PUNTO_MUESTREO 2 to CONTAMINANTE"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b1\\b/,\"Dióxido de Azufre\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b1\\b/,\"Dióxido de Azufre\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(\"6\",\"Monóxido de Carbono\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(\"6\",\"Monóxido de Carbono\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b7\\b/,\"Monóxido de Nitrógeno\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b7\\b/,\"Monóxido de Nitrógeno\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b8\\b/,\"Dióxido de Nitrógeno\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b8\\b/,\"Dióxido de Nitrógeno\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b9\\b/,\"Partículas < 2.5 μm\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b9\\b/,\"Partículas < 2.5 μm\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b10\\b/,\"Partículas < 10 μm\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b10\\b/,\"Partículas < 10 μm\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b12\\b/,\"Óxidos de Nitrógeno\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b12\\b/,\"Óxidos de Nitrógeno\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b14\\b/,\"Ozono\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b14\\b/,\"Ozono\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b20\\b/,\"Tolueno\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b20\\b/,\"Tolueno\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b30\\b/,\"Benceno\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b30\\b/,\"Benceno\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b35\\b/,\"Etilbenceno\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b35\\b/,\"Etilbenceno\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b37\\b/,\"Metaxileno\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b37\\b/,\"Metaxileno\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b38\\b/,\"Paraxileno\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b38\\b/,\"Paraxileno\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b39\\b/,\"Ortoxileno\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b39\\b/,\"Ortoxileno\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b42\\b/,\"Hidrocarburos totales (hexano)\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b42\\b/,\"Hidrocarburos totales (hexano)\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b43\\b/,\"Metano\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b43\\b/,\"Metano\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "expression": "value.replace(/\\b44\\b/,\"Hidrocarburos no metánicos (hexano)\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column CONTAMINANTE using expression value.replace(/\\b44\\b/,\"Hidrocarburos no metánicos (hexano)\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "expression": "value.replace(/\\b38\\b/,\"Fluorescencia ultravioleta\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column TECNICA using expression value.replace(/\\b38\\b/,\"Fluorescencia ultravioleta\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "expression": "value.replace(/\\b48\\b/,\"Absorción infrarroja\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column TECNICA using expression value.replace(/\\b48\\b/,\"Absorción infrarroja\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "expression": "value.replace(/\\b8\\b/,\"Quimioluminiscencia\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column TECNICA using expression value.replace(/\\b8\\b/,\"Quimioluminiscencia\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "expression": "value.replace(/\\b47\\b/,\"Microbalanza\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column TECNICA using expression value.replace(/\\b47\\b/,\"Microbalanza\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "expression": "value.replace(/\\b6\\b/,\"Absorción ultravioleta\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column TECNICA using expression value.replace(/\\b6\\b/,\"Absorción ultravioleta\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "expression": "value.replace(/\\b59\\b/,\"Cromatografía de gases\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column TECNICA using expression value.replace(/\\b59\\b/,\"Cromatografía de gases\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "expression": "value.replace(\"2\",\"Ionización de llama\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column TECNICA using expression value.replace(\"2\",\"Ionización de llama\")"
+  },
+  {
+    "op": "core/column-addition",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "baseColumnName": "TECNICA",
+    "expression": "grel:value",
+    "onError": "set-to-blank",
+    "newColumnName": "UNIDAD",
+    "columnInsertIndex": 4,
+    "description": "Create column UNIDAD at index 4 based on column TECNICA using expression grel:value"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "UNIDAD",
+    "expression": "value.replace(\"Fluorescencia ultravioleta\",\"μg/m^3\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column UNIDAD using expression value.replace(\"Fluorescencia ultravioleta\",\"μg/m^3\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "UNIDAD",
+    "expression": "value.replace(\"Absorción infrarroja\",\"mg/m^3\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column UNIDAD using expression value.replace(\"Absorción infrarroja\",\"mg/m^3\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "UNIDAD",
+    "expression": "value.replace(\"Quimioluminiscencia\",\"μg/m^3\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column UNIDAD using expression value.replace(\"Quimioluminiscencia\",\"μg/m^3\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "UNIDAD",
+    "expression": "value.replace(\"Microbalanza\",\"μg/m^3\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column UNIDAD using expression value.replace(\"Microbalanza\",\"μg/m^3\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "UNIDAD",
+    "expression": "value.replace(\"Absorción ultravioleta\",\"μg/m^3\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column UNIDAD using expression value.replace(\"Absorción ultravioleta\",\"μg/m^3\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "UNIDAD",
+    "expression": "value.replace(\"Cromatografía de gases\",\"μg/m^3\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column UNIDAD using expression value.replace(\"Cromatografía de gases\",\"μg/m^3\")"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "UNIDAD",
+    "expression": "value.replace(\"Ionización de llama\",\"mg/m^3\")",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column UNIDAD using expression value.replace(\"Ionización de llama\",\"mg/m^3\")"
+  },
+  {
+    "op": "rdf-extension/save-rdf-schema",
+    "schema": {
+      "prefixes": [
+        {
+          "name": "rdf",
+          "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        {
+          "name": "owl",
+          "uri": "http://www.w3.org/2002/07/owl#"
+        },
+        {
+          "name": "xml",
+          "uri": "http://www.w3.org/XML/1998/namespace#"
+        },
+        {
+          "name": "xsd",
+          "uri": "http://www.w3.org/2001/XMLSchema#"
+        },
+        {
+          "name": "rdfs",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        {
+          "name": "aqm",
+          "uri": "http://www.airQualityMadrid.com/ontology#"
+        }
+      ],
+      "baseUri": "http://www.airQualityMadrid.com/resource/",
+      "rootNodes": [
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "ID_MEDICION",
+          "expression": "\"Measurement/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_medicion",
+              "curie": "aqm:id_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_MEDICION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_estacion",
+              "curie": "aqm:id_estacion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_ESTACION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#contaminante",
+              "curie": "aqm:contaminante",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "CONTAMINANTE",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#tecnica",
+              "curie": "aqm:tecnica",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "TECNICA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#unidad",
+              "curie": "aqm:unidad",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "UNIDAD",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#fecha",
+              "curie": "aqm:fecha",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "FECHA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_1",
+              "curie": "aqm:valor_a_las_1",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H01",
+                "expression": "value",
+                "valueType": "http://www.w3.org/2001/XMLSchema#int",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_2",
+              "curie": "aqm:valor_a_las_2",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H02",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_3",
+              "curie": "aqm:valor_a_las_3",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H03",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_4",
+              "curie": "aqm:valor_a_las_4",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H04",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_5",
+              "curie": "aqm:valor_a_las_5",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H05",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_6",
+              "curie": "aqm:valor_a_las_6",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H06",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_7",
+              "curie": "aqm:valor_a_las_7",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H07",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_8",
+              "curie": "aqm:valor_a_las_8",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H08",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_9",
+              "curie": "aqm:valor_a_las_9",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H09",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_10",
+              "curie": "aqm:valor_a_las_10",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H10",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_11",
+              "curie": "aqm:valor_a_las_11",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H11",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_12",
+              "curie": "aqm:valor_a_las_12",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H12",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_13",
+              "curie": "aqm:valor_a_las_13",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H13",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_14",
+              "curie": "aqm:valor_a_las_14",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H14",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_15",
+              "curie": "aqm:valor_a_las_15",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H15",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_16",
+              "curie": "aqm:valor_a_las_16",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H16",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_17",
+              "curie": "aqm:valor_a_las_17",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H17",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_18",
+              "curie": "aqm:valor_a_las_18",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H18",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_19",
+              "curie": "aqm:valor_a_las_19",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H19",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_20",
+              "curie": "aqm:valor_a_las_20",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H20",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_21",
+              "curie": "aqm:valor_a_las_21",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H21",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_22",
+              "curie": "aqm:valor_a_las_22",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H22",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_23",
+              "curie": "aqm:valor_a_las_23",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H23",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_24",
+              "curie": "aqm:valor_a_las_24",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H24",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Measurement",
+              "curie": "aqm:Measurement"
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF schema skeleton"
+  },
+  {
+    "op": "rdf-extension/save-rdf-schema",
+    "schema": {
+      "prefixes": [
+        {
+          "name": "rdf",
+          "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        {
+          "name": "owl",
+          "uri": "http://www.w3.org/2002/07/owl#"
+        },
+        {
+          "name": "xml",
+          "uri": "http://www.w3.org/XML/1998/namespace#"
+        },
+        {
+          "name": "xsd",
+          "uri": "http://www.w3.org/2001/XMLSchema#"
+        },
+        {
+          "name": "rdfs",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        {
+          "name": "aqm",
+          "uri": "http://www.airQualityMadrid.com/ontology#"
+        }
+      ],
+      "baseUri": "http://www.airQualityMadrid.com/resource/",
+      "rootNodes": [
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "ID_MEDICION",
+          "expression": "\"Measurement/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_medicion",
+              "curie": "aqm:id_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_MEDICION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_estacion",
+              "curie": "aqm:id_estacion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_ESTACION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#contaminante",
+              "curie": "aqm:contaminante",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "CONTAMINANTE",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#tecnica",
+              "curie": "aqm:tecnica",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "TECNICA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#unidad",
+              "curie": "aqm:unidad",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "UNIDAD",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#fecha",
+              "curie": "aqm:fecha",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "FECHA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_1",
+              "curie": "aqm:valor_a_las_1",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H01",
+                "expression": "value",
+                "valueType": "http://www.w3.org/2001/XMLSchema#int",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_2",
+              "curie": "aqm:valor_a_las_2",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H02",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_3",
+              "curie": "aqm:valor_a_las_3",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H03",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_4",
+              "curie": "aqm:valor_a_las_4",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H04",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_5",
+              "curie": "aqm:valor_a_las_5",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H05",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_6",
+              "curie": "aqm:valor_a_las_6",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H06",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_7",
+              "curie": "aqm:valor_a_las_7",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H07",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_8",
+              "curie": "aqm:valor_a_las_8",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H08",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_9",
+              "curie": "aqm:valor_a_las_9",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H09",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_10",
+              "curie": "aqm:valor_a_las_10",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H10",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_11",
+              "curie": "aqm:valor_a_las_11",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H11",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_12",
+              "curie": "aqm:valor_a_las_12",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H12",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_13",
+              "curie": "aqm:valor_a_las_13",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H13",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_14",
+              "curie": "aqm:valor_a_las_14",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H14",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_15",
+              "curie": "aqm:valor_a_las_15",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H15",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_16",
+              "curie": "aqm:valor_a_las_16",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H16",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_17",
+              "curie": "aqm:valor_a_las_17",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H17",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_18",
+              "curie": "aqm:valor_a_las_18",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H18",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_19",
+              "curie": "aqm:valor_a_las_19",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H19",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_20",
+              "curie": "aqm:valor_a_las_20",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H20",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_21",
+              "curie": "aqm:valor_a_las_21",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H21",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_22",
+              "curie": "aqm:valor_a_las_22",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H22",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_23",
+              "curie": "aqm:valor_a_las_23",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H23",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_24",
+              "curie": "aqm:valor_a_las_24",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H24",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Measurement",
+              "curie": "aqm:Measurement"
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF schema skeleton"
+  },
+  {
+    "op": "rdf-extension/save-rdf-schema",
+    "schema": {
+      "prefixes": [
+        {
+          "name": "rdf",
+          "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        {
+          "name": "owl",
+          "uri": "http://www.w3.org/2002/07/owl#"
+        },
+        {
+          "name": "xml",
+          "uri": "http://www.w3.org/XML/1998/namespace#"
+        },
+        {
+          "name": "xsd",
+          "uri": "http://www.w3.org/2001/XMLSchema#"
+        },
+        {
+          "name": "rdfs",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        {
+          "name": "aqm",
+          "uri": "http://www.airQualityMadrid.com/ontology#"
+        }
+      ],
+      "baseUri": "http://www.airQualityMadrid.com/resource/",
+      "rootNodes": [
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "ID_MEDICION",
+          "expression": "\"Measurement/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_medicion",
+              "curie": "aqm:id_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_MEDICION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_estacion",
+              "curie": "aqm:id_estacion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_ESTACION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#contaminante",
+              "curie": "aqm:contaminante",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "CONTAMINANTE",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#tecnica",
+              "curie": "aqm:tecnica",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "TECNICA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#unidad",
+              "curie": "aqm:unidad",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "UNIDAD",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#fecha",
+              "curie": "aqm:fecha",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "FECHA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_1",
+              "curie": "aqm:valor_a_las_1",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H01",
+                "expression": "value",
+                "valueType": "http://www.w3.org/2001/XMLSchema#int",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_2",
+              "curie": "aqm:valor_a_las_2",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H02",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_3",
+              "curie": "aqm:valor_a_las_3",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H03",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_4",
+              "curie": "aqm:valor_a_las_4",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H04",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_5",
+              "curie": "aqm:valor_a_las_5",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H05",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_6",
+              "curie": "aqm:valor_a_las_6",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H06",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_7",
+              "curie": "aqm:valor_a_las_7",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H07",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_8",
+              "curie": "aqm:valor_a_las_8",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H08",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_9",
+              "curie": "aqm:valor_a_las_9",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H09",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_10",
+              "curie": "aqm:valor_a_las_10",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H10",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_11",
+              "curie": "aqm:valor_a_las_11",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H11",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_12",
+              "curie": "aqm:valor_a_las_12",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H12",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_13",
+              "curie": "aqm:valor_a_las_13",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H13",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_14",
+              "curie": "aqm:valor_a_las_14",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H14",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_15",
+              "curie": "aqm:valor_a_las_15",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H15",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_16",
+              "curie": "aqm:valor_a_las_16",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H16",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_17",
+              "curie": "aqm:valor_a_las_17",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H17",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_18",
+              "curie": "aqm:valor_a_las_18",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H18",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_19",
+              "curie": "aqm:valor_a_las_19",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H19",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_20",
+              "curie": "aqm:valor_a_las_20",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H20",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_21",
+              "curie": "aqm:valor_a_las_21",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H21",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_22",
+              "curie": "aqm:valor_a_las_22",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H22",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_23",
+              "curie": "aqm:valor_a_las_23",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H23",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_24",
+              "curie": "aqm:valor_a_las_24",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H24",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Measurement",
+              "curie": "aqm:Measurement"
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF schema skeleton"
+  },
+  {
+    "op": "core/column-split",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "FECHA",
+    "guessCellType": true,
+    "removeOriginalColumn": true,
+    "mode": "separator",
+    "separator": "-",
+    "regex": false,
+    "maxColumns": 0,
+    "description": "Split column FECHA by separator"
+  },
+  {
+    "op": "core/text-transform",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "FECHA 3",
+    "expression": "grel:value + '-' + cells['FECHA 2'].value + '-' + cells['FECHA 1'].value",
+    "onError": "keep-original",
+    "repeat": false,
+    "repeatCount": 10,
+    "description": "Text transform on cells in column FECHA 3 using expression grel:value + '-' + cells['FECHA 2'].value + '-' + cells['FECHA 1'].value"
+  },
+  {
+    "op": "core/column-removal",
+    "columnName": "FECHA 1",
+    "description": "Remove column FECHA 1"
+  },
+  {
+    "op": "core/column-removal",
+    "columnName": "FECHA 2",
+    "description": "Remove column FECHA 2"
+  },
+  {
+    "op": "core/column-rename",
+    "oldColumnName": "FECHA 3",
+    "newColumnName": "FECHA",
+    "description": "Rename column FECHA 3 to FECHA"
+  },
+  {
+    "op": "rdf-extension/save-rdf-schema",
+    "schema": {
+      "prefixes": [
+        {
+          "name": "rdf",
+          "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        {
+          "name": "owl",
+          "uri": "http://www.w3.org/2002/07/owl#"
+        },
+        {
+          "name": "xml",
+          "uri": "http://www.w3.org/XML/1998/namespace#"
+        },
+        {
+          "name": "xsd",
+          "uri": "http://www.w3.org/2001/XMLSchema#"
+        },
+        {
+          "name": "rdfs",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        {
+          "name": "aqm",
+          "uri": "http://www.airQualityMadrid.com/ontology#"
+        }
+      ],
+      "baseUri": "http://www.airQualityMadrid.com/resource/",
+      "rootNodes": [
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "ID_MEDICION",
+          "expression": "\"Measurement/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_medicion",
+              "curie": "aqm:id_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_MEDICION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_estacion",
+              "curie": "aqm:id_estacion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_ESTACION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#contaminante",
+              "curie": "aqm:contaminante",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "CONTAMINANTE",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#tecnica",
+              "curie": "aqm:tecnica",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "TECNICA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#unidad",
+              "curie": "aqm:unidad",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "UNIDAD",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#fecha",
+              "curie": "aqm:fecha",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "FECHA",
+                "expression": "value",
+                "valueType": "http://www.w3.org/2001/XMLSchema#date",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_1",
+              "curie": "aqm:valor_a_las_1",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H01",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_2",
+              "curie": "aqm:valor_a_las_2",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H02",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_3",
+              "curie": "aqm:valor_a_las_3",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H03",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_4",
+              "curie": "aqm:valor_a_las_4",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H04",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_5",
+              "curie": "aqm:valor_a_las_5",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H05",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_6",
+              "curie": "aqm:valor_a_las_6",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H06",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_7",
+              "curie": "aqm:valor_a_las_7",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H07",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_8",
+              "curie": "aqm:valor_a_las_8",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H08",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_9",
+              "curie": "aqm:valor_a_las_9",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H09",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_10",
+              "curie": "aqm:valor_a_las_10",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H10",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_11",
+              "curie": "aqm:valor_a_las_11",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H11",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_12",
+              "curie": "aqm:valor_a_las_12",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H12",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_13",
+              "curie": "aqm:valor_a_las_13",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H13",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_14",
+              "curie": "aqm:valor_a_las_14",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H14",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_15",
+              "curie": "aqm:valor_a_las_15",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H15",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_16",
+              "curie": "aqm:valor_a_las_16",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H16",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_17",
+              "curie": "aqm:valor_a_las_17",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H17",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_18",
+              "curie": "aqm:valor_a_las_18",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H18",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_19",
+              "curie": "aqm:valor_a_las_19",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H19",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_20",
+              "curie": "aqm:valor_a_las_20",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H20",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_21",
+              "curie": "aqm:valor_a_las_21",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H21",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_22",
+              "curie": "aqm:valor_a_las_22",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H22",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_23",
+              "curie": "aqm:valor_a_las_23",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H23",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_24",
+              "curie": "aqm:valor_a_las_24",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H24",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Measurement",
+              "curie": "aqm:Measurement"
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF schema skeleton"
+  },
+  {
+    "op": "rdf-extension/save-rdf-schema",
+    "schema": {
+      "prefixes": [
+        {
+          "name": "rdf",
+          "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        {
+          "name": "owl",
+          "uri": "http://www.w3.org/2002/07/owl#"
+        },
+        {
+          "name": "xml",
+          "uri": "http://www.w3.org/XML/1998/namespace#"
+        },
+        {
+          "name": "xsd",
+          "uri": "http://www.w3.org/2001/XMLSchema#"
+        },
+        {
+          "name": "rdfs",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        {
+          "name": "aqm",
+          "uri": "http://www.airQualityMadrid.com/ontology#"
+        }
+      ],
+      "baseUri": "http://www.airQualityMadrid.com/resource/",
+      "rootNodes": [
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "ID_MEDICION",
+          "expression": "\"Measurement/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_medicion",
+              "curie": "aqm:id_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_MEDICION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_estacion",
+              "curie": "aqm:id_estacion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_ESTACION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#contaminante",
+              "curie": "aqm:contaminante",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "CONTAMINANTE",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#tecnica",
+              "curie": "aqm:tecnica",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "TECNICA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#unidad",
+              "curie": "aqm:unidad",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "UNIDAD",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#fecha",
+              "curie": "aqm:fecha",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "FECHA",
+                "expression": "value",
+                "valueType": "http://www.w3.org/2001/XMLSchema#date",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_1",
+              "curie": "aqm:valor_a_las_1",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H01",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_2",
+              "curie": "aqm:valor_a_las_2",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H02",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_3",
+              "curie": "aqm:valor_a_las_3",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H03",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_4",
+              "curie": "aqm:valor_a_las_4",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H04",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_5",
+              "curie": "aqm:valor_a_las_5",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H05",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_6",
+              "curie": "aqm:valor_a_las_6",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H06",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_7",
+              "curie": "aqm:valor_a_las_7",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H07",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_8",
+              "curie": "aqm:valor_a_las_8",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H08",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_9",
+              "curie": "aqm:valor_a_las_9",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H09",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_10",
+              "curie": "aqm:valor_a_las_10",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H10",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_11",
+              "curie": "aqm:valor_a_las_11",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H11",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_12",
+              "curie": "aqm:valor_a_las_12",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H12",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_13",
+              "curie": "aqm:valor_a_las_13",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H13",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_14",
+              "curie": "aqm:valor_a_las_14",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H14",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_15",
+              "curie": "aqm:valor_a_las_15",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H15",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_16",
+              "curie": "aqm:valor_a_las_16",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H16",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_17",
+              "curie": "aqm:valor_a_las_17",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H17",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_18",
+              "curie": "aqm:valor_a_las_18",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H18",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_19",
+              "curie": "aqm:valor_a_las_19",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H19",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_20",
+              "curie": "aqm:valor_a_las_20",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H20",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_21",
+              "curie": "aqm:valor_a_las_21",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H21",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_22",
+              "curie": "aqm:valor_a_las_22",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H22",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_23",
+              "curie": "aqm:valor_a_las_23",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H23",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_24",
+              "curie": "aqm:valor_a_las_24",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H24",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Measurement",
+              "curie": "aqm:Measurement"
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF schema skeleton"
+  },
+  {
+    "op": "rdf-extension/save-rdf-schema",
+    "schema": {
+      "prefixes": [
+        {
+          "name": "rdf",
+          "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        {
+          "name": "owl",
+          "uri": "http://www.w3.org/2002/07/owl#"
+        },
+        {
+          "name": "xml",
+          "uri": "http://www.w3.org/XML/1998/namespace#"
+        },
+        {
+          "name": "xsd",
+          "uri": "http://www.w3.org/2001/XMLSchema#"
+        },
+        {
+          "name": "rdfs",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        {
+          "name": "aqm",
+          "uri": "http://www.airQualityMadrid.com/ontology#"
+        }
+      ],
+      "baseUri": "http://www.airQualityMadrid.com/resource/",
+      "rootNodes": [
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "ID_MEDICION",
+          "expression": "\"Measurement/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_medicion",
+              "curie": "aqm:id_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_MEDICION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_estacion",
+              "curie": "aqm:id_estacion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_ESTACION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#contaminante",
+              "curie": "aqm:contaminante",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "CONTAMINANTE",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#tecnica",
+              "curie": "aqm:tecnica",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "TECNICA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#unidad",
+              "curie": "aqm:unidad",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "UNIDAD",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#fecha",
+              "curie": "aqm:fecha",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "FECHA",
+                "expression": "value",
+                "valueType": "http://www.w3.org/2001/XMLSchema#date",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_1",
+              "curie": "aqm:valor_a_las_1",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H01",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_2",
+              "curie": "aqm:valor_a_las_2",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H02",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_3",
+              "curie": "aqm:valor_a_las_3",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H03",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_4",
+              "curie": "aqm:valor_a_las_4",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H04",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_5",
+              "curie": "aqm:valor_a_las_5",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H05",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_6",
+              "curie": "aqm:valor_a_las_6",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H06",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_7",
+              "curie": "aqm:valor_a_las_7",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H07",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_8",
+              "curie": "aqm:valor_a_las_8",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H08",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_9",
+              "curie": "aqm:valor_a_las_9",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H09",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_10",
+              "curie": "aqm:valor_a_las_10",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H10",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_11",
+              "curie": "aqm:valor_a_las_11",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H11",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_12",
+              "curie": "aqm:valor_a_las_12",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H12",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_13",
+              "curie": "aqm:valor_a_las_13",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H13",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_14",
+              "curie": "aqm:valor_a_las_14",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H14",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_15",
+              "curie": "aqm:valor_a_las_15",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H15",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_16",
+              "curie": "aqm:valor_a_las_16",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H16",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_17",
+              "curie": "aqm:valor_a_las_17",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H17",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_18",
+              "curie": "aqm:valor_a_las_18",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H18",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_19",
+              "curie": "aqm:valor_a_las_19",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H19",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_20",
+              "curie": "aqm:valor_a_las_20",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H20",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_21",
+              "curie": "aqm:valor_a_las_21",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H21",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_22",
+              "curie": "aqm:valor_a_las_22",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H22",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_23",
+              "curie": "aqm:valor_a_las_23",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H23",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_24",
+              "curie": "aqm:valor_a_las_24",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H24",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Measurement",
+              "curie": "aqm:Measurement"
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF schema skeleton"
+  },
+  {
+    "op": "rdf-extension/save-rdf-schema",
+    "schema": {
+      "prefixes": [
+        {
+          "name": "rdf",
+          "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        {
+          "name": "owl",
+          "uri": "http://www.w3.org/2002/07/owl#"
+        },
+        {
+          "name": "xml",
+          "uri": "http://www.w3.org/XML/1998/namespace#"
+        },
+        {
+          "name": "xsd",
+          "uri": "http://www.w3.org/2001/XMLSchema#"
+        },
+        {
+          "name": "rdfs",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        {
+          "name": "aqm",
+          "uri": "http://www.airQualityMadrid.com/ontology#"
+        }
+      ],
+      "baseUri": "http://www.airQualityMadrid.com/resource/",
+      "rootNodes": [
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "ID_MEDICION",
+          "expression": "\"Measurement/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_medicion",
+              "curie": "aqm:id_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_MEDICION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_estacion",
+              "curie": "aqm:id_estacion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_ESTACION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#contaminante",
+              "curie": "aqm:contaminante",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "CONTAMINANTE",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#tecnica",
+              "curie": "aqm:tecnica",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "TECNICA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#unidad",
+              "curie": "aqm:unidad",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "UNIDAD",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#fecha",
+              "curie": "aqm:fecha",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "FECHA",
+                "expression": "value",
+                "valueType": "http://www.w3.org/2001/XMLSchema#date",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_1",
+              "curie": "aqm:valor_a_las_1",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H01",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_2",
+              "curie": "aqm:valor_a_las_2",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H02",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_3",
+              "curie": "aqm:valor_a_las_3",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H03",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_4",
+              "curie": "aqm:valor_a_las_4",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H04",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_5",
+              "curie": "aqm:valor_a_las_5",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H05",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_6",
+              "curie": "aqm:valor_a_las_6",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H06",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_7",
+              "curie": "aqm:valor_a_las_7",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H07",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_8",
+              "curie": "aqm:valor_a_las_8",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H08",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_9",
+              "curie": "aqm:valor_a_las_9",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H09",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_10",
+              "curie": "aqm:valor_a_las_10",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H10",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_11",
+              "curie": "aqm:valor_a_las_11",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H11",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_12",
+              "curie": "aqm:valor_a_las_12",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H12",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_13",
+              "curie": "aqm:valor_a_las_13",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H13",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_14",
+              "curie": "aqm:valor_a_las_14",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H14",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_15",
+              "curie": "aqm:valor_a_las_15",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H15",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_16",
+              "curie": "aqm:valor_a_las_16",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H16",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_17",
+              "curie": "aqm:valor_a_las_17",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H17",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_18",
+              "curie": "aqm:valor_a_las_18",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H18",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_19",
+              "curie": "aqm:valor_a_las_19",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H19",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_20",
+              "curie": "aqm:valor_a_las_20",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H20",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_21",
+              "curie": "aqm:valor_a_las_21",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H21",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_22",
+              "curie": "aqm:valor_a_las_22",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H22",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_23",
+              "curie": "aqm:valor_a_las_23",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H23",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_24",
+              "curie": "aqm:valor_a_las_24",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H24",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Measurement",
+              "curie": "aqm:Measurement"
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF schema skeleton"
+  },
+  {
+    "op": "core/recon",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "config": {
+      "mode": "standard-service",
+      "service": "https://tools.wmflabs.org/openrefine-wikidata/en/api",
+      "identifierSpace": "http://www.wikidata.org/entity/",
+      "schemaSpace": "http://www.wikidata.org/prop/direct/",
+      "type": {
+        "id": "Q11173",
+        "name": "chemical compound"
+      },
+      "autoMatch": true,
+      "columnDetails": [],
+      "limit": 0
+    },
+    "description": "Reconcile cells in column CONTAMINANTE to type Q11173"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Dióxido de Azufre",
+    "judgment": "matched",
+    "match": {
+      "id": "Q5282",
+      "name": "sulfur dioxide",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item sulfur dioxide (Q5282) for cells containing \"Dióxido de Azufre\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Monóxido de Carbono",
+    "judgment": "matched",
+    "match": {
+      "id": "Q2025",
+      "name": "carbon monoxide",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item carbon monoxide (Q2025) for cells containing \"Monóxido de Carbono\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Monóxido de Nitrógeno",
+    "judgment": "matched",
+    "match": {
+      "id": "Q207843",
+      "name": "nitric oxide (radical)",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item nitric oxide (radical) (Q207843) for cells containing \"Monóxido de Nitrógeno\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Dióxido de Nitrógeno",
+    "judgment": "matched",
+    "match": {
+      "id": "Q207895",
+      "name": "nitrogen dioxide",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item nitrogen dioxide (Q207895) for cells containing \"Dióxido de Nitrógeno\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Óxidos de Nitrógeno",
+    "judgment": "matched",
+    "match": {
+      "id": "Q424418",
+      "name": "nitrogen oxide",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item nitrogen oxide (Q424418) for cells containing \"Óxidos de Nitrógeno\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-clear-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Partículas < 2.5 μm",
+    "description": "Clear recon data for cells containing \"Partículas < 2.5 μm\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-clear-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Partículas < 10 μm",
+    "description": "Clear recon data for cells containing \"Partículas < 10 μm\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Ozono",
+    "judgment": "matched",
+    "match": {
+      "id": "Q36933",
+      "name": "ozone",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item ozone (Q36933) for cells containing \"Ozono\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Tolueno",
+    "judgment": "matched",
+    "match": {
+      "id": "Q15779",
+      "name": "toluene",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item toluene (Q15779) for cells containing \"Tolueno\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Benceno",
+    "judgment": "matched",
+    "match": {
+      "id": "Q2270",
+      "name": "benzene",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item benzene (Q2270) for cells containing \"Benceno\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Etilbenceno",
+    "judgment": "matched",
+    "match": {
+      "id": "Q409184",
+      "name": "ethylbenzene",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item ethylbenzene (Q409184) for cells containing \"Etilbenceno\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-clear-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Hidrocarburos totales (hexano)",
+    "description": "Clear recon data for cells containing \"Hidrocarburos totales (hexano)\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Metano",
+    "judgment": "matched",
+    "match": {
+      "id": "Q37129",
+      "name": "methane",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item methane (Q37129) for cells containing \"Metano\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-clear-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Hidrocarburos no metánicos (hexano)",
+    "description": "Clear recon data for cells containing \"Hidrocarburos no metánicos (hexano)\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "config": {
+      "mode": "standard-service",
+      "service": "https://tools.wmflabs.org/openrefine-wikidata/en/api",
+      "identifierSpace": "http://www.wikidata.org/entity/",
+      "schemaSpace": "http://www.wikidata.org/prop/direct/",
+      "type": {
+        "id": "Q13442814",
+        "name": "scholarly article"
+      },
+      "autoMatch": true,
+      "columnDetails": [],
+      "limit": 0
+    },
+    "description": "Reconcile cells in column TECNICA to type Q13442814"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "similarValue": "Fluorescencia ultravioleta",
+    "judgment": "matched",
+    "match": {
+      "id": "Q191807",
+      "name": "fluorescence",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item fluorescence (Q191807) for cells containing \"Fluorescencia ultravioleta\" in column TECNICA"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "similarValue": "Absorción infrarroja",
+    "judgment": "matched",
+    "match": {
+      "id": "Q70906",
+      "name": "infrared spectroscopy",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item infrared spectroscopy (Q70906) for cells containing \"Absorción infrarroja\" in column TECNICA"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "similarValue": "Quimioluminiscencia",
+    "judgment": "matched",
+    "match": {
+      "id": "Q2931725",
+      "name": "Chemiluminescence",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item Chemiluminescence (Q2931725) for cells containing \"Quimioluminiscencia\" in column TECNICA"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "similarValue": "Microbalanza",
+    "judgment": "matched",
+    "match": {
+      "id": "Q629569",
+      "name": "Quartz crystal microbalance",
+      "types": [
+        ""
+      ],
+      "score": 33.5
+    },
+    "shareNewTopics": false,
+    "description": "Match item Quartz crystal microbalance (Q629569) for cells containing \"Microbalanza\" in column TECNICA"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "similarValue": "Cromatografía de gases",
+    "judgment": "matched",
+    "match": {
+      "id": "Q677065",
+      "name": "Gas chromatography",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item Gas chromatography (Q677065) for cells containing \"Cromatografía de gases\" in column TECNICA"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "similarValue": "Ionización de llama",
+    "judgment": "matched",
+    "match": {
+      "id": "Q873305",
+      "name": "Flame ionization detector",
+      "types": [
+        ""
+      ],
+      "score": 38
+    },
+    "shareNewTopics": false,
+    "description": "Match item Flame ionization detector (Q873305) for cells containing \"Ionización de llama\" in column TECNICA"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "TECNICA",
+    "similarValue": "Absorción ultravioleta",
+    "judgment": "matched",
+    "match": {
+      "id": "Q332828",
+      "name": "absorption",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item absorption (Q332828) for cells containing \"Absorción ultravioleta\" in column TECNICA"
+  },
+  {
+    "op": "core/column-addition",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "baseColumnName": "CONTAMINANTE",
+    "expression": "grel:\"https://www.wikidata.org/wiki/\" + cell.recon.match.id",
+    "onError": "set-to-blank",
+    "newColumnName": "Chemical Agent",
+    "columnInsertIndex": 3,
+    "description": "Create column Chemical Agent at index 3 based on column CONTAMINANTE using expression grel:\"https://www.wikidata.org/wiki/\" + cell.recon.match.id"
+  },
+  {
+    "op": "core/column-rename",
+    "oldColumnName": "Chemical Agent",
+    "newColumnName": "Chemical Compound",
+    "description": "Rename column Chemical Agent to Chemical Compound"
+  },
+  {
+    "op": "core/column-addition",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "baseColumnName": "TECNICA",
+    "expression": "grel:\"https://www.wikidata.org/wiki/\" + cell.recon.match.id",
+    "onError": "set-to-blank",
+    "newColumnName": "Technique",
+    "columnInsertIndex": 5,
+    "description": "Create column Technique at index 5 based on column TECNICA using expression grel:\"https://www.wikidata.org/wiki/\" + cell.recon.match.id"
+  },
+  {
+    "op": "rdf-extension/save-rdf-schema",
+    "schema": {
+      "prefixes": [
+        {
+          "name": "rdf",
+          "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        {
+          "name": "owl",
+          "uri": "http://www.w3.org/2002/07/owl#"
+        },
+        {
+          "name": "xml",
+          "uri": "http://www.w3.org/XML/1998/namespace#"
+        },
+        {
+          "name": "xsd",
+          "uri": "http://www.w3.org/2001/XMLSchema#"
+        },
+        {
+          "name": "rdfs",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        {
+          "name": "aqm",
+          "uri": "http://www.airQualityMadrid.com/ontology#"
+        }
+      ],
+      "baseUri": "http://www.airQualityMadrid.com/resource/",
+      "rootNodes": [
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "ID_MEDICION",
+          "expression": "\"Measurement/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_medicion",
+              "curie": "aqm:id_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_MEDICION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_estacion",
+              "curie": "aqm:id_estacion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_ESTACION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#contaminante",
+              "curie": "aqm:contaminante",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "CONTAMINANTE",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#tecnica",
+              "curie": "aqm:tecnica",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "TECNICA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#unidad",
+              "curie": "aqm:unidad",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "UNIDAD",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#fecha",
+              "curie": "aqm:fecha",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "FECHA",
+                "expression": "value",
+                "valueType": "http://www.w3.org/2001/XMLSchema#date",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_1",
+              "curie": "aqm:valor_a_las_1",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H01",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_2",
+              "curie": "aqm:valor_a_las_2",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H02",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_3",
+              "curie": "aqm:valor_a_las_3",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H03",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_4",
+              "curie": "aqm:valor_a_las_4",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H04",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_5",
+              "curie": "aqm:valor_a_las_5",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H05",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_6",
+              "curie": "aqm:valor_a_las_6",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H06",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_7",
+              "curie": "aqm:valor_a_las_7",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H07",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_8",
+              "curie": "aqm:valor_a_las_8",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H08",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_9",
+              "curie": "aqm:valor_a_las_9",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H09",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_10",
+              "curie": "aqm:valor_a_las_10",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H10",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_11",
+              "curie": "aqm:valor_a_las_11",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H11",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_12",
+              "curie": "aqm:valor_a_las_12",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H12",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_13",
+              "curie": "aqm:valor_a_las_13",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H13",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_14",
+              "curie": "aqm:valor_a_las_14",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H14",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_15",
+              "curie": "aqm:valor_a_las_15",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H15",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_16",
+              "curie": "aqm:valor_a_las_16",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H16",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_17",
+              "curie": "aqm:valor_a_las_17",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H17",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_18",
+              "curie": "aqm:valor_a_las_18",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H18",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_19",
+              "curie": "aqm:valor_a_las_19",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H19",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_20",
+              "curie": "aqm:valor_a_las_20",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H20",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_21",
+              "curie": "aqm:valor_a_las_21",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H21",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_22",
+              "curie": "aqm:valor_a_las_22",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H22",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_23",
+              "curie": "aqm:valor_a_las_23",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H23",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_24",
+              "curie": "aqm:valor_a_las_24",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H24",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Measurement",
+              "curie": "aqm:Measurement"
+            }
+          ]
+        },
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "CONTAMINANTE",
+          "expression": "\"Contaminante/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.w3.org/2002/07/owl#sameAs",
+              "curie": "owl:sameAs",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "Chemical Compound",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Contaminante",
+              "curie": "aqm:Contaminante"
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF schema skeleton"
+  },
+  {
+    "op": "rdf-extension/save-rdf-schema",
+    "schema": {
+      "prefixes": [
+        {
+          "name": "rdf",
+          "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        {
+          "name": "owl",
+          "uri": "http://www.w3.org/2002/07/owl#"
+        },
+        {
+          "name": "xml",
+          "uri": "http://www.w3.org/XML/1998/namespace#"
+        },
+        {
+          "name": "xsd",
+          "uri": "http://www.w3.org/2001/XMLSchema#"
+        },
+        {
+          "name": "rdfs",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        {
+          "name": "aqm",
+          "uri": "http://www.airQualityMadrid.com/ontology#"
+        }
+      ],
+      "baseUri": "http://www.airQualityMadrid.com/resource/",
+      "rootNodes": [
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "ID_MEDICION",
+          "expression": "\"Measurement/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_medicion",
+              "curie": "aqm:id_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_MEDICION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_estacion",
+              "curie": "aqm:id_estacion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_ESTACION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#contaminante",
+              "curie": "aqm:contaminante",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "CONTAMINANTE",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#tecnica",
+              "curie": "aqm:tecnica",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "TECNICA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#unidad",
+              "curie": "aqm:unidad",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "UNIDAD",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#fecha",
+              "curie": "aqm:fecha",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "FECHA",
+                "expression": "value",
+                "valueType": "http://www.w3.org/2001/XMLSchema#date",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_1",
+              "curie": "aqm:valor_a_las_1",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H01",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_2",
+              "curie": "aqm:valor_a_las_2",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H02",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_3",
+              "curie": "aqm:valor_a_las_3",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H03",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_4",
+              "curie": "aqm:valor_a_las_4",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H04",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_5",
+              "curie": "aqm:valor_a_las_5",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H05",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_6",
+              "curie": "aqm:valor_a_las_6",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H06",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_7",
+              "curie": "aqm:valor_a_las_7",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H07",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_8",
+              "curie": "aqm:valor_a_las_8",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H08",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_9",
+              "curie": "aqm:valor_a_las_9",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H09",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_10",
+              "curie": "aqm:valor_a_las_10",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H10",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_11",
+              "curie": "aqm:valor_a_las_11",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H11",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_12",
+              "curie": "aqm:valor_a_las_12",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H12",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_13",
+              "curie": "aqm:valor_a_las_13",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H13",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_14",
+              "curie": "aqm:valor_a_las_14",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H14",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_15",
+              "curie": "aqm:valor_a_las_15",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H15",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_16",
+              "curie": "aqm:valor_a_las_16",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H16",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_17",
+              "curie": "aqm:valor_a_las_17",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H17",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_18",
+              "curie": "aqm:valor_a_las_18",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H18",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_19",
+              "curie": "aqm:valor_a_las_19",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H19",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_20",
+              "curie": "aqm:valor_a_las_20",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H20",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_21",
+              "curie": "aqm:valor_a_las_21",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H21",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_22",
+              "curie": "aqm:valor_a_las_22",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H22",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_23",
+              "curie": "aqm:valor_a_las_23",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H23",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_24",
+              "curie": "aqm:valor_a_las_24",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H24",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Measurement",
+              "curie": "aqm:Measurement"
+            }
+          ]
+        },
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "CONTAMINANTE",
+          "expression": "\"Contaminante/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.w3.org/2002/07/owl#sameAs",
+              "curie": "owl:sameAs",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "Chemical Compound",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Contaminante",
+              "curie": "aqm:Contaminante"
+            }
+          ]
+        },
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "TECNICA",
+          "expression": "\"Tecnica/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.w3.org/2002/07/owl#sameAs",
+              "curie": "owl:sameAs",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "Technique",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Tecnica",
+              "curie": "aqm:Tecnica"
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF schema skeleton"
+  },
+  {
+    "op": "core/recon",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "config": {
+      "mode": "standard-service",
+      "service": "https://tools.wmflabs.org/openrefine-wikidata/en/api",
+      "identifierSpace": "http://www.wikidata.org/entity/",
+      "schemaSpace": "http://www.wikidata.org/prop/direct/",
+      "type": {
+        "id": "Q11173",
+        "name": "chemical compound"
+      },
+      "autoMatch": true,
+      "columnDetails": [],
+      "limit": 0
+    },
+    "description": "Reconcile cells in column CONTAMINANTE to type Q11173"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Monóxido de Nitrógeno",
+    "judgment": "matched",
+    "match": {
+      "id": "Q207843",
+      "name": "nitric oxide (radical)",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item nitric oxide (radical) (Q207843) for cells containing \"Monóxido de Nitrógeno\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Dióxido de Nitrógeno",
+    "judgment": "matched",
+    "match": {
+      "id": "Q207895",
+      "name": "nitrogen dioxide",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item nitrogen dioxide (Q207895) for cells containing \"Dióxido de Nitrógeno\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Óxidos de Nitrógeno",
+    "judgment": "matched",
+    "match": {
+      "id": "Q424418",
+      "name": "nitrogen oxide",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item nitrogen oxide (Q424418) for cells containing \"Óxidos de Nitrógeno\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Ozono",
+    "judgment": "matched",
+    "match": {
+      "id": "Q36933",
+      "name": "ozone",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item ozone (Q36933) for cells containing \"Ozono\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Tolueno",
+    "judgment": "matched",
+    "match": {
+      "id": "Q15779",
+      "name": "toluene",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item toluene (Q15779) for cells containing \"Tolueno\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Benceno",
+    "judgment": "matched",
+    "match": {
+      "id": "Q2270",
+      "name": "benzene",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item benzene (Q2270) for cells containing \"Benceno\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Etilbenceno",
+    "judgment": "matched",
+    "match": {
+      "id": "Q409184",
+      "name": "ethylbenzene",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item ethylbenzene (Q409184) for cells containing \"Etilbenceno\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Metano",
+    "judgment": "matched",
+    "match": {
+      "id": "Q37129",
+      "name": "methane",
+      "types": [
+        ""
+      ],
+      "score": 100
+    },
+    "shareNewTopics": false,
+    "description": "Match item methane (Q37129) for cells containing \"Metano\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Partículas < 2.5 μm",
+    "judgment": "new",
+    "shareNewTopics": true,
+    "description": "Mark to create one single new item for all cells containing \"Partículas < 2.5 μm\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Partículas < 10 μm",
+    "judgment": "new",
+    "shareNewTopics": true,
+    "description": "Mark to create one single new item for all cells containing \"Partículas < 10 μm\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Hidrocarburos totales (hexano)",
+    "judgment": "new",
+    "shareNewTopics": true,
+    "description": "Mark to create one single new item for all cells containing \"Hidrocarburos totales (hexano)\" in column CONTAMINANTE"
+  },
+  {
+    "op": "core/recon-judge-similar-cells",
+    "engineConfig": {
+      "facets": [],
+      "mode": "row-based"
+    },
+    "columnName": "CONTAMINANTE",
+    "similarValue": "Hidrocarburos no metánicos (hexano)",
+    "judgment": "new",
+    "shareNewTopics": true,
+    "description": "Mark to create one single new item for all cells containing \"Hidrocarburos no metánicos (hexano)\" in column CONTAMINANTE"
+  },
+  {
+    "op": "rdf-extension/save-rdf-schema",
+    "schema": {
+      "prefixes": [
+        {
+          "name": "rdf",
+          "uri": "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        },
+        {
+          "name": "owl",
+          "uri": "http://www.w3.org/2002/07/owl#"
+        },
+        {
+          "name": "xml",
+          "uri": "http://www.w3.org/XML/1998/namespace#"
+        },
+        {
+          "name": "xsd",
+          "uri": "http://www.w3.org/2001/XMLSchema#"
+        },
+        {
+          "name": "rdfs",
+          "uri": "http://www.w3.org/2000/01/rdf-schema#"
+        },
+        {
+          "name": "aqm",
+          "uri": "http://www.airQualityMadrid.com/ontology#"
+        }
+      ],
+      "baseUri": "http://www.airQualityMadrid.com/resource/",
+      "rootNodes": [
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "ID_MEDICION",
+          "expression": "\"Measurement/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_medicion",
+              "curie": "aqm:id_medicion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_MEDICION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#id_estacion",
+              "curie": "aqm:id_estacion",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "ID_ESTACION",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#contaminante",
+              "curie": "aqm:contaminante",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "CONTAMINANTE",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#tecnica",
+              "curie": "aqm:tecnica",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "TECNICA",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#unidad",
+              "curie": "aqm:unidad",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "UNIDAD",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#fecha",
+              "curie": "aqm:fecha",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "FECHA",
+                "expression": "value",
+                "valueType": "http://www.w3.org/2001/XMLSchema#date",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_1",
+              "curie": "aqm:valor_a_las_1",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H01",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_2",
+              "curie": "aqm:valor_a_las_2",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H02",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_3",
+              "curie": "aqm:valor_a_las_3",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H03",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_4",
+              "curie": "aqm:valor_a_las_4",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H04",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_5",
+              "curie": "aqm:valor_a_las_5",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H05",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_6",
+              "curie": "aqm:valor_a_las_6",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H06",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_7",
+              "curie": "aqm:valor_a_las_7",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H07",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_8",
+              "curie": "aqm:valor_a_las_8",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H08",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_9",
+              "curie": "aqm:valor_a_las_9",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H09",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_10",
+              "curie": "aqm:valor_a_las_10",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H10",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_11",
+              "curie": "aqm:valor_a_las_11",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H11",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_12",
+              "curie": "aqm:valor_a_las_12",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H12",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_13",
+              "curie": "aqm:valor_a_las_13",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H13",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_14",
+              "curie": "aqm:valor_a_las_14",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H14",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_15",
+              "curie": "aqm:valor_a_las_15",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H15",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_16",
+              "curie": "aqm:valor_a_las_16",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H16",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_17",
+              "curie": "aqm:valor_a_las_17",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H17",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_18",
+              "curie": "aqm:valor_a_las_18",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H18",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_19",
+              "curie": "aqm:valor_a_las_19",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H19",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_20",
+              "curie": "aqm:valor_a_las_20",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H20",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_21",
+              "curie": "aqm:valor_a_las_21",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H21",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_22",
+              "curie": "aqm:valor_a_las_22",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H22",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_23",
+              "curie": "aqm:valor_a_las_23",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H23",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            },
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#valor_a_las_24",
+              "curie": "aqm:valor_a_las_24",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "H24",
+                "expression": "value",
+                "valueType": "xsd:double",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Measurement",
+              "curie": "aqm:Measurement"
+            }
+          ]
+        },
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "CONTAMINANTE",
+          "expression": "\"Contaminante/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.w3.org/2002/07/owl#sameAs",
+              "curie": "owl:sameAs",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "Chemical Compound",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Contaminante",
+              "curie": "aqm:Contaminante"
+            }
+          ]
+        },
+        {
+          "nodeType": "cell-as-resource",
+          "columnName": "TECNICA",
+          "expression": "\"Tecnica/\" + value",
+          "isRowNumberCell": false,
+          "links": [
+            {
+              "uri": "http://www.w3.org/2002/07/owl#sameAs",
+              "curie": "owl:sameAs",
+              "target": {
+                "nodeType": "cell-as-literal",
+                "columnName": "Technique",
+                "expression": "value",
+                "isRowNumberCell": false
+              }
+            }
+          ],
+          "rdfTypes": [
+            {
+              "uri": "http://www.airQualityMadrid.com/ontology#Tecnica",
+              "curie": "aqm:Tecnica"
+            }
+          ]
+        }
+      ]
+    },
+    "description": "Save RDF schema skeleton"
+  }
+]

--- a/HandsOn/Group15/ontology/ontology.ttl
+++ b/HandsOn/Group15/ontology/ontology.ttl
@@ -21,6 +21,12 @@
 ###  http://www.airQualityMadrid.com/ontology#Measurement
 :Measurement rdf:type owl:Class .
 
+###  http://www.airQualityMadrid.com/ontology#Contaminante
+:Contaminante rdf:type owl:Class .
+
+###  http://www.airQualityMadrid.com/ontology#Tecnica
+:Tecnica rdf:type owl:Class .
+
 #################################################################
 #    Object Properties
 #################################################################

--- a/HandsOn/Group15/ontology/ontology.ttl
+++ b/HandsOn/Group15/ontology/ontology.ttl
@@ -77,13 +77,13 @@ geo:long rdf:type owl:DatatypeProperty ;
              rdfs:domain :Station;
              rdfs:range xsd:float .
 			 
-###  http://www.airQualityMadrid.com/ontology#CONTAMINANTE
-:contaminante rdf:type owl:DatatypeProperty ;
+###  http://www.airQualityMadrid.com/ontology#CONTAMINANTE_MEDIDO
+:contaminante_medido rdf:type owl:DatatypeProperty ;
              rdfs:domain :Measurement ;
              rdfs:range xsd:string .
 			 
-###  http://www.airQualityMadrid.com/ontology#TECNICA
-:tecnica rdf:type owl:DatatypeProperty ;
+###  http://www.airQualityMadrid.com/ontology#TECNICA_MEDICION
+:tecnica_medicion rdf:type owl:DatatypeProperty ;
              rdfs:domain :Measurement ;
              rdfs:range xsd:string .
 			 

--- a/HandsOn/Group15/ontology/ontology.ttl
+++ b/HandsOn/Group15/ontology/ontology.ttl
@@ -4,7 +4,10 @@
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sosa: <http://www.w3.org/ns/sosa/> .
+@prefix geo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
 @base <http://www.airQualityMadrid.com/ontology#> .
+
 
 <http://www.airQualityMadrid.com/ontology#> rdf:type owl:Ontology .
 
@@ -58,13 +61,13 @@
              rdfs:domain :Station;
              rdfs:range xsd:string .
 			 
-###  http://www.airQualityMadrid.com/ontology#LATITUD
-:latitud rdf:type owl:DatatypeProperty ;
+###  http://www.w3.org/2003/01/geo/wgs84_pos#lat
+geo:lat rdf:type owl:DatatypeProperty ;
              rdfs:domain :Station;
              rdfs:range xsd:float .
 			 
-###  http://www.airQualityMadrid.com/ontology#LONGITUD
-:longitud rdf:type owl:DatatypeProperty ;
+###  http://www.w3.org/2003/01/geo/wgs84_pos#long
+geo:long rdf:type owl:DatatypeProperty ;
              rdfs:domain :Station;
              rdfs:range xsd:float .
 			 
@@ -211,19 +214,4 @@
 ###  http://www.airQualityMadrid.com/ontology#LOCALIZACION
 :localizacion rdf:type owl:DatatypeProperty ;
              rdfs:domain :Station ;
-             rdfs:range xsd:string .
-			 
-###  http://www.airQualityMadrid.com/ontology#NOMBRE
-<http://dbpedia.org/ontology/name> rdf:type owl:DatatypeProperty ;
-				 rdfs:domain :Station ;
-				 rdfs:range xsd:string .
-
-###  http://www.airQualityMadrid.com/ontology#LATITUD
-:latitud rdf:type owl:DatatypeProperty ;
-				 rdfs:domain :Station ;
-				 rdfs:range xsd:float .
-
-###  http://www.airQualityMadrid.com/ontology#LATITUD
-:longitud rdf:type owl:DatatypeProperty ;
-				 rdfs:domain :Station ;
-				 rdfs:range xsd:float .				 
+             rdfs:range xsd:string .			 

--- a/HandsOn/Group15/rdf/rdfDatosEstaciones-with-links.ttl
+++ b/HandsOn/Group15/rdf/rdfDatosEstaciones-with-links.ttl
@@ -1,4 +1,3 @@
-@prefix geo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace#> .
@@ -8,11 +7,11 @@
 
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079004_1_38> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Azufre";
+  aqm:contaminante_medido "Dióxido de Azufre";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079004";
   aqm:id_medicion "28079004_1_38";
-  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:tecnica_medicion "Fluorescencia ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00012"^^<xsd:double>;
   aqm:valor_a_las_10 "00009"^^<xsd:double>;
@@ -48,11 +47,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079004_6_48> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Carbono";
+  aqm:contaminante_medido "Monóxido de Carbono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079004";
   aqm:id_medicion "28079004_6_48";
-  aqm:tecnica "Absorción infrarroja";
+  aqm:tecnica_medicion "Absorción infrarroja";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "000.2"^^<xsd:double>;
   aqm:valor_a_las_10 "000.4"^^<xsd:double>;
@@ -87,11 +86,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079004_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079004";
   aqm:id_medicion "28079004_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00023"^^<xsd:double>;
@@ -126,11 +125,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079004_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079004";
   aqm:id_medicion "28079004_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00013"^^<xsd:double>;
   aqm:valor_a_las_10 "00057"^^<xsd:double>;
@@ -162,11 +161,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079004_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079004";
   aqm:id_medicion "28079004_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00015"^^<xsd:double>;
   aqm:valor_a_las_10 "00092"^^<xsd:double>;
@@ -198,11 +197,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_1_38> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Azufre";
+  aqm:contaminante_medido "Dióxido de Azufre";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_1_38";
-  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:tecnica_medicion "Fluorescencia ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00005"^^<xsd:double>;
   aqm:valor_a_las_10 "00005"^^<xsd:double>;
@@ -238,11 +237,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_6_48> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Carbono";
+  aqm:contaminante_medido "Monóxido de Carbono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_6_48";
-  aqm:tecnica "Absorción infrarroja";
+  aqm:tecnica_medicion "Absorción infrarroja";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "000.2"^^<xsd:double>;
   aqm:valor_a_las_10 "000.4"^^<xsd:double>;
@@ -277,11 +276,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00002"^^<xsd:double>;
   aqm:valor_a_las_10 "00024"^^<xsd:double>;
@@ -316,11 +315,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00017"^^<xsd:double>;
   aqm:valor_a_las_10 "00057"^^<xsd:double>;
@@ -352,11 +351,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_9_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:contaminante_medido "Partículas < 2.5 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_9_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00006"^^<xsd:double>;
   aqm:valor_a_las_10 "00011"^^<xsd:double>;
@@ -390,11 +389,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_10_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 10 μm";
+  aqm:contaminante_medido "Partículas < 10 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_10_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00013"^^<xsd:double>;
   aqm:valor_a_las_10 "00022"^^<xsd:double>;
@@ -425,11 +424,11 @@
   a aqm:Contaminante .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00020"^^<xsd:double>;
   aqm:valor_a_las_10 "00094"^^<xsd:double>;
@@ -464,11 +463,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "68.97"^^<xsd:double>;
   aqm:valor_a_las_10 "26.21"^^<xsd:double>;
@@ -503,11 +502,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_20_59> a aqm:Measurement;
-  aqm:contaminante "Tolueno";
+  aqm:contaminante_medido "Tolueno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_20_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "002.1"^^<xsd:double>;
   aqm:valor_a_las_10 "004.7"^^<xsd:double>;
@@ -542,11 +541,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_30_59> a aqm:Measurement;
-  aqm:contaminante "Benceno";
+  aqm:contaminante_medido "Benceno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_30_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "000.5"^^<xsd:double>;
   aqm:valor_a_las_10 "001.0"^^<xsd:double>;
@@ -577,11 +576,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2270" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_35_59> a aqm:Measurement;
-  aqm:contaminante "Etilbenceno";
+  aqm:contaminante_medido "Etilbenceno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_35_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "004.2"^^<xsd:double>;
   aqm:valor_a_las_10 "002.8"^^<xsd:double>;
@@ -612,11 +611,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q409184" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_42_2> a aqm:Measurement;
-  aqm:contaminante "Hidrocarburos totales (hexano)";
+  aqm:contaminante_medido "Hidrocarburos totales (hexano)";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_42_2";
-  aqm:tecnica "Ionización de llama";
+  aqm:tecnica_medicion "Ionización de llama";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "01.60"^^<xsd:double>;
   aqm:valor_a_las_10 "01.65"^^<xsd:double>;
@@ -650,11 +649,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q873305" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_43_2> a aqm:Measurement;
-  aqm:contaminante "Metano";
+  aqm:contaminante_medido "Metano";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_43_2";
-  aqm:tecnica "Ionización de llama";
+  aqm:tecnica_medicion "Ionización de llama";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "01.48"^^<xsd:double>;
   aqm:valor_a_las_10 "01.49"^^<xsd:double>;
@@ -685,11 +684,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q37129" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079008_44_2> a aqm:Measurement;
-  aqm:contaminante "Hidrocarburos no metánicos (hexano)";
+  aqm:contaminante_medido "Hidrocarburos no metánicos (hexano)";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079008";
   aqm:id_medicion "28079008_44_2";
-  aqm:tecnica "Ionización de llama";
+  aqm:tecnica_medicion "Ionización de llama";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "00.12"^^<xsd:double>;
   aqm:valor_a_las_10 "00.17"^^<xsd:double>;
@@ -720,11 +719,11 @@
   a aqm:Contaminante .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079011_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079011";
   aqm:id_medicion "28079011_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00043"^^<xsd:double>;
@@ -759,11 +758,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079011_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079011";
   aqm:id_medicion "28079011_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00013"^^<xsd:double>;
   aqm:valor_a_las_10 "00075"^^<xsd:double>;
@@ -795,11 +794,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079011_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079011";
   aqm:id_medicion "28079011_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00015"^^<xsd:double>;
   aqm:valor_a_las_10 "00141"^^<xsd:double>;
@@ -831,11 +830,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079011_20_59> a aqm:Measurement;
-  aqm:contaminante "Tolueno";
+  aqm:contaminante_medido "Tolueno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079011";
   aqm:id_medicion "28079011_20_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "001.0"^^<xsd:double>;
   aqm:valor_a_las_10 "005.8"^^<xsd:double>;
@@ -870,11 +869,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079011_30_59> a aqm:Measurement;
-  aqm:contaminante "Benceno";
+  aqm:contaminante_medido "Benceno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079011";
   aqm:id_medicion "28079011_30_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "000.1"^^<xsd:double>;
   aqm:valor_a_las_10 "000.8"^^<xsd:double>;
@@ -905,11 +904,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2270" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079011_35_59> a aqm:Measurement;
-  aqm:contaminante "Etilbenceno";
+  aqm:contaminante_medido "Etilbenceno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079011";
   aqm:id_medicion "28079011_35_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "000.2"^^<xsd:double>;
   aqm:valor_a_las_10 "000.5"^^<xsd:double>;
@@ -940,11 +939,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q409184" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079016_6_48> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Carbono";
+  aqm:contaminante_medido "Monóxido de Carbono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079016";
   aqm:id_medicion "28079016_6_48";
-  aqm:tecnica "Absorción infrarroja";
+  aqm:tecnica_medicion "Absorción infrarroja";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "000.1"^^<xsd:double>;
   aqm:valor_a_las_10 "000.4"^^<xsd:double>;
@@ -979,11 +978,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079016_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079016";
   aqm:id_medicion "28079016_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00020"^^<xsd:double>;
@@ -1018,11 +1017,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079016_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079016";
   aqm:id_medicion "28079016_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00009"^^<xsd:double>;
   aqm:valor_a_las_10 "00068"^^<xsd:double>;
@@ -1054,11 +1053,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079016_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079016";
   aqm:id_medicion "28079016_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00010"^^<xsd:double>;
   aqm:valor_a_las_10 "00099"^^<xsd:double>;
@@ -1090,11 +1089,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079016_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079016";
   aqm:id_medicion "28079016_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "46.65"^^<xsd:double>;
   aqm:valor_a_las_10 "03.99"^^<xsd:double>;
@@ -1129,11 +1128,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079017_1_38> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Azufre";
+  aqm:contaminante_medido "Dióxido de Azufre";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079017";
   aqm:id_medicion "28079017_1_38";
-  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:tecnica_medicion "Fluorescencia ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00009"^^<xsd:double>;
   aqm:valor_a_las_10 "00010"^^<xsd:double>;
@@ -1169,11 +1168,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079017_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079017";
   aqm:id_medicion "28079017_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00002"^^<xsd:double>;
   aqm:valor_a_las_10 "00010"^^<xsd:double>;
@@ -1208,11 +1207,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079017_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079017";
   aqm:id_medicion "28079017_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00013"^^<xsd:double>;
   aqm:valor_a_las_10 "00036"^^<xsd:double>;
@@ -1244,11 +1243,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079017_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079017";
   aqm:id_medicion "28079017_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00016"^^<xsd:double>;
   aqm:valor_a_las_10 "00052"^^<xsd:double>;
@@ -1280,11 +1279,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079017_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079017";
   aqm:id_medicion "28079017_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "64.59"^^<xsd:double>;
   aqm:valor_a_las_10 "36.56"^^<xsd:double>;
@@ -1319,11 +1318,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079018_1_38> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Azufre";
+  aqm:contaminante_medido "Dióxido de Azufre";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079018";
   aqm:id_medicion "28079018_1_38";
-  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:tecnica_medicion "Fluorescencia ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00006"^^<xsd:double>;
   aqm:valor_a_las_10 "00006"^^<xsd:double>;
@@ -1359,11 +1358,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079018_6_48> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Carbono";
+  aqm:contaminante_medido "Monóxido de Carbono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079018";
   aqm:id_medicion "28079018_6_48";
-  aqm:tecnica "Absorción infrarroja";
+  aqm:tecnica_medicion "Absorción infrarroja";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "000.3"^^<xsd:double>;
   aqm:valor_a_las_10 "000.4"^^<xsd:double>;
@@ -1398,11 +1397,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079018_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079018";
   aqm:id_medicion "28079018_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00006"^^<xsd:double>;
@@ -1437,11 +1436,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079018_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079018";
   aqm:id_medicion "28079018_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00010"^^<xsd:double>;
   aqm:valor_a_las_10 "00028"^^<xsd:double>;
@@ -1473,11 +1472,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079018_10_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 10 μm";
+  aqm:contaminante_medido "Partículas < 10 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079018";
   aqm:id_medicion "28079018_10_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00007"^^<xsd:double>;
   aqm:valor_a_las_10 "00011"^^<xsd:double>;
@@ -1511,11 +1510,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079018_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079018";
   aqm:id_medicion "28079018_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00012"^^<xsd:double>;
   aqm:valor_a_las_10 "00037"^^<xsd:double>;
@@ -1550,11 +1549,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079018_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079018";
   aqm:id_medicion "28079018_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "66.45"^^<xsd:double>;
   aqm:valor_a_las_10 "39.09"^^<xsd:double>;
@@ -1589,11 +1588,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079018_20_59> a aqm:Measurement;
-  aqm:contaminante "Tolueno";
+  aqm:contaminante_medido "Tolueno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079018";
   aqm:id_medicion "28079018_20_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "001.0"^^<xsd:double>;
   aqm:valor_a_las_10 "001.4"^^<xsd:double>;
@@ -1628,11 +1627,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079018_30_59> a aqm:Measurement;
-  aqm:contaminante "Benceno";
+  aqm:contaminante_medido "Benceno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079018";
   aqm:id_medicion "28079018_30_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "000.1"^^<xsd:double>;
   aqm:valor_a_las_10 "000.2"^^<xsd:double>;
@@ -1663,11 +1662,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2270" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079018_35_59> a aqm:Measurement;
-  aqm:contaminante "Etilbenceno";
+  aqm:contaminante_medido "Etilbenceno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079018";
   aqm:id_medicion "28079018_35_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "000.1"^^<xsd:double>;
   aqm:valor_a_las_10 "000.2"^^<xsd:double>;
@@ -1702,11 +1701,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_1_38> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Azufre";
+  aqm:contaminante_medido "Dióxido de Azufre";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_1_38";
-  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:tecnica_medicion "Fluorescencia ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00004"^^<xsd:double>;
   aqm:valor_a_las_10 "00004"^^<xsd:double>;
@@ -1742,11 +1741,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_6_48> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Carbono";
+  aqm:contaminante_medido "Monóxido de Carbono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_6_48";
-  aqm:tecnica "Absorción infrarroja";
+  aqm:tecnica_medicion "Absorción infrarroja";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "000.1"^^<xsd:double>;
   aqm:valor_a_las_10 "000.2"^^<xsd:double>;
@@ -1781,11 +1780,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00003"^^<xsd:double>;
@@ -1820,11 +1819,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00003"^^<xsd:double>;
   aqm:valor_a_las_10 "00019"^^<xsd:double>;
@@ -1856,11 +1855,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_9_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:contaminante_medido "Partículas < 2.5 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_9_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00000"^^<xsd:double>;
   aqm:valor_a_las_10 "00000"^^<xsd:double>;
@@ -1894,11 +1893,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_10_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 10 μm";
+  aqm:contaminante_medido "Partículas < 10 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_10_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00000"^^<xsd:double>;
   aqm:valor_a_las_10 "00000"^^<xsd:double>;
@@ -1929,11 +1928,11 @@
   a aqm:Contaminante .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00004"^^<xsd:double>;
   aqm:valor_a_las_10 "00023"^^<xsd:double>;
@@ -1968,11 +1967,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "80.48"^^<xsd:double>;
   aqm:valor_a_las_10 "52.17"^^<xsd:double>;
@@ -2007,11 +2006,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_20_59> a aqm:Measurement;
-  aqm:contaminante "Tolueno";
+  aqm:contaminante_medido "Tolueno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_20_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "000.1"^^<xsd:double>;
   aqm:valor_a_las_10 "000.4"^^<xsd:double>;
@@ -2046,11 +2045,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_30_59> a aqm:Measurement;
-  aqm:contaminante "Benceno";
+  aqm:contaminante_medido "Benceno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_30_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "000.1"^^<xsd:double>;
   aqm:valor_a_las_10 "000.1"^^<xsd:double>;
@@ -2081,11 +2080,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2270" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_35_59> a aqm:Measurement;
-  aqm:contaminante "Etilbenceno";
+  aqm:contaminante_medido "Etilbenceno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_35_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "000.1"^^<xsd:double>;
   aqm:valor_a_las_10 "000.1"^^<xsd:double>;
@@ -2120,11 +2119,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_42_2> a aqm:Measurement;
-  aqm:contaminante "Hidrocarburos totales (hexano)";
+  aqm:contaminante_medido "Hidrocarburos totales (hexano)";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_42_2";
-  aqm:tecnica "Ionización de llama";
+  aqm:tecnica_medicion "Ionización de llama";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "01.16"^^<xsd:double>;
   aqm:valor_a_las_10 "01.17"^^<xsd:double>;
@@ -2158,11 +2157,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q873305" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_43_2> a aqm:Measurement;
-  aqm:contaminante "Metano";
+  aqm:contaminante_medido "Metano";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_43_2";
-  aqm:tecnica "Ionización de llama";
+  aqm:tecnica_medicion "Ionización de llama";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "01.10"^^<xsd:double>;
   aqm:valor_a_las_10 "01.09"^^<xsd:double>;
@@ -2193,11 +2192,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q37129" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079024_44_2> a aqm:Measurement;
-  aqm:contaminante "Hidrocarburos no metánicos (hexano)";
+  aqm:contaminante_medido "Hidrocarburos no metánicos (hexano)";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079024";
   aqm:id_medicion "28079024_44_2";
-  aqm:tecnica "Ionización de llama";
+  aqm:tecnica_medicion "Ionización de llama";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "00.06"^^<xsd:double>;
   aqm:valor_a_las_10 "00.08"^^<xsd:double>;
@@ -2231,11 +2230,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q873305" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079027_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079027";
   aqm:id_medicion "28079027_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00033"^^<xsd:double>;
@@ -2270,11 +2269,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079027_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079027";
   aqm:id_medicion "28079027_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00052"^^<xsd:double>;
   aqm:valor_a_las_10 "00073"^^<xsd:double>;
@@ -2306,11 +2305,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079027_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079027";
   aqm:id_medicion "28079027_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00054"^^<xsd:double>;
   aqm:valor_a_las_10 "00123"^^<xsd:double>;
@@ -2345,11 +2344,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079027_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079027";
   aqm:id_medicion "28079027_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "35.55"^^<xsd:double>;
   aqm:valor_a_las_10 "16.90"^^<xsd:double>;
@@ -2384,11 +2383,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079035_1_38> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Azufre";
+  aqm:contaminante_medido "Dióxido de Azufre";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079035";
   aqm:id_medicion "28079035_1_38";
-  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:tecnica_medicion "Fluorescencia ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00009"^^<xsd:double>;
   aqm:valor_a_las_10 "00012"^^<xsd:double>;
@@ -2424,11 +2423,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079035_6_48> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Carbono";
+  aqm:contaminante_medido "Monóxido de Carbono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079035";
   aqm:id_medicion "28079035_6_48";
-  aqm:tecnica "Absorción infrarroja";
+  aqm:tecnica_medicion "Absorción infrarroja";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "000.8"^^<xsd:double>;
   aqm:valor_a_las_10 "000.9"^^<xsd:double>;
@@ -2463,11 +2462,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079035_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079035";
   aqm:id_medicion "28079035_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00015"^^<xsd:double>;
@@ -2502,11 +2501,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079035_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079035";
   aqm:id_medicion "28079035_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00016"^^<xsd:double>;
   aqm:valor_a_las_10 "00049"^^<xsd:double>;
@@ -2538,11 +2537,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079035_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079035";
   aqm:id_medicion "28079035_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00019"^^<xsd:double>;
   aqm:valor_a_las_10 "00072"^^<xsd:double>;
@@ -2577,11 +2576,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079035_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079035";
   aqm:id_medicion "28079035_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "63.05"^^<xsd:double>;
   aqm:valor_a_las_10 "26.21"^^<xsd:double>;
@@ -2616,11 +2615,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079036_1_38> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Azufre";
+  aqm:contaminante_medido "Dióxido de Azufre";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079036";
   aqm:id_medicion "28079036_1_38";
-  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:tecnica_medicion "Fluorescencia ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00004"^^<xsd:double>;
   aqm:valor_a_las_10 "00004"^^<xsd:double>;
@@ -2656,11 +2655,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079036_6_48> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Carbono";
+  aqm:contaminante_medido "Monóxido de Carbono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079036";
   aqm:id_medicion "28079036_6_48";
-  aqm:tecnica "Absorción infrarroja";
+  aqm:tecnica_medicion "Absorción infrarroja";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "000.2"^^<xsd:double>;
   aqm:valor_a_las_10 "000.4"^^<xsd:double>;
@@ -2695,11 +2694,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079036_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079036";
   aqm:id_medicion "28079036_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00003"^^<xsd:double>;
   aqm:valor_a_las_10 "00025"^^<xsd:double>;
@@ -2734,11 +2733,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079036_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079036";
   aqm:id_medicion "28079036_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00009"^^<xsd:double>;
   aqm:valor_a_las_10 "00056"^^<xsd:double>;
@@ -2770,11 +2769,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079036_10_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 10 μm";
+  aqm:contaminante_medido "Partículas < 10 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079036";
   aqm:id_medicion "28079036_10_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00012"^^<xsd:double>;
   aqm:valor_a_las_10 "00021"^^<xsd:double>;
@@ -2808,11 +2807,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079036_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079036";
   aqm:id_medicion "28079036_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00013"^^<xsd:double>;
   aqm:valor_a_las_10 "00094"^^<xsd:double>;
@@ -2847,11 +2846,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079038_1_38> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Azufre";
+  aqm:contaminante_medido "Dióxido de Azufre";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079038";
   aqm:id_medicion "28079038_1_38";
-  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:tecnica_medicion "Fluorescencia ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00007"^^<xsd:double>;
   aqm:valor_a_las_10 "00009"^^<xsd:double>;
@@ -2887,11 +2886,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079038_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079038";
   aqm:id_medicion "28079038_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00003"^^<xsd:double>;
   aqm:valor_a_las_10 "00039"^^<xsd:double>;
@@ -2926,11 +2925,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079038_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079038";
   aqm:id_medicion "28079038_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00011"^^<xsd:double>;
   aqm:valor_a_las_10 "00061"^^<xsd:double>;
@@ -2962,11 +2961,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079038_9_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:contaminante_medido "Partículas < 2.5 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079038";
   aqm:id_medicion "28079038_9_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00002"^^<xsd:double>;
   aqm:valor_a_las_10 "00009"^^<xsd:double>;
@@ -3000,11 +2999,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079038_10_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 10 μm";
+  aqm:contaminante_medido "Partículas < 10 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079038";
   aqm:id_medicion "28079038_10_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00008"^^<xsd:double>;
   aqm:valor_a_las_10 "00018"^^<xsd:double>;
@@ -3035,11 +3034,11 @@
   a aqm:Contaminante .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079038_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079038";
   aqm:id_medicion "28079038_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00015"^^<xsd:double>;
   aqm:valor_a_las_10 "00121"^^<xsd:double>;
@@ -3074,11 +3073,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079038_20_59> a aqm:Measurement;
-  aqm:contaminante "Tolueno";
+  aqm:contaminante_medido "Tolueno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079038";
   aqm:id_medicion "28079038_20_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "000.7"^^<xsd:double>;
   aqm:valor_a_las_10 "001.4"^^<xsd:double>;
@@ -3113,11 +3112,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079038_30_59> a aqm:Measurement;
-  aqm:contaminante "Benceno";
+  aqm:contaminante_medido "Benceno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079038";
   aqm:id_medicion "28079038_30_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "000.3"^^<xsd:double>;
   aqm:valor_a_las_10 "000.5"^^<xsd:double>;
@@ -3148,11 +3147,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2270" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079038_35_59> a aqm:Measurement;
-  aqm:contaminante "Etilbenceno";
+  aqm:contaminante_medido "Etilbenceno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079038";
   aqm:id_medicion "28079038_35_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "004.0"^^<xsd:double>;
   aqm:valor_a_las_10 "004.0"^^<xsd:double>;
@@ -3187,11 +3186,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079039_6_48> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Carbono";
+  aqm:contaminante_medido "Monóxido de Carbono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079039";
   aqm:id_medicion "28079039_6_48";
-  aqm:tecnica "Absorción infrarroja";
+  aqm:tecnica_medicion "Absorción infrarroja";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "000.2"^^<xsd:double>;
   aqm:valor_a_las_10 "000.3"^^<xsd:double>;
@@ -3226,11 +3225,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079039_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079039";
   aqm:id_medicion "28079039_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00010"^^<xsd:double>;
@@ -3265,11 +3264,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079039_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079039";
   aqm:id_medicion "28079039_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00005"^^<xsd:double>;
   aqm:valor_a_las_10 "00044"^^<xsd:double>;
@@ -3301,11 +3300,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079039_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079039";
   aqm:id_medicion "28079039_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00007"^^<xsd:double>;
   aqm:valor_a_las_10 "00060"^^<xsd:double>;
@@ -3340,11 +3339,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079039_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079039";
   aqm:id_medicion "28079039_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "89.28"^^<xsd:double>;
   aqm:valor_a_las_10 "40.92"^^<xsd:double>;
@@ -3379,11 +3378,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079040_1_38> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Azufre";
+  aqm:contaminante_medido "Dióxido de Azufre";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079040";
   aqm:id_medicion "28079040_1_38";
-  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:tecnica_medicion "Fluorescencia ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00009"^^<xsd:double>;
   aqm:valor_a_las_10 "00009"^^<xsd:double>;
@@ -3419,11 +3418,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079040_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079040";
   aqm:id_medicion "28079040_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00002"^^<xsd:double>;
   aqm:valor_a_las_10 "00021"^^<xsd:double>;
@@ -3458,11 +3457,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079040_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079040";
   aqm:id_medicion "28079040_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00013"^^<xsd:double>;
   aqm:valor_a_las_10 "00060"^^<xsd:double>;
@@ -3494,11 +3493,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079040_10_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 10 μm";
+  aqm:contaminante_medido "Partículas < 10 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079040";
   aqm:id_medicion "28079040_10_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00008"^^<xsd:double>;
   aqm:valor_a_las_10 "00025"^^<xsd:double>;
@@ -3532,11 +3531,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079040_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079040";
   aqm:id_medicion "28079040_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00015"^^<xsd:double>;
   aqm:valor_a_las_10 "00092"^^<xsd:double>;
@@ -3571,11 +3570,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079047_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079047";
   aqm:id_medicion "28079047_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00005"^^<xsd:double>;
@@ -3607,11 +3606,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079047_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079047";
   aqm:id_medicion "28079047_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00016"^^<xsd:double>;
   aqm:valor_a_las_10 "00045"^^<xsd:double>;
@@ -3646,11 +3645,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079047_9_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:contaminante_medido "Partículas < 2.5 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079047";
   aqm:id_medicion "28079047_9_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00014"^^<xsd:double>;
   aqm:valor_a_las_10 "00009"^^<xsd:double>;
@@ -3684,11 +3683,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079047_10_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 10 μm";
+  aqm:contaminante_medido "Partículas < 10 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079047";
   aqm:id_medicion "28079047_10_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00020"^^<xsd:double>;
   aqm:valor_a_las_10 "00017"^^<xsd:double>;
@@ -3719,11 +3718,11 @@
   a aqm:Contaminante .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079047_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079047";
   aqm:id_medicion "28079047_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00017"^^<xsd:double>;
   aqm:valor_a_las_10 "00053"^^<xsd:double>;
@@ -3758,11 +3757,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079048_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079048";
   aqm:id_medicion "28079048_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00020"^^<xsd:double>;
@@ -3794,11 +3793,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079048_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079048";
   aqm:id_medicion "28079048_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00009"^^<xsd:double>;
   aqm:valor_a_las_10 "00047"^^<xsd:double>;
@@ -3833,11 +3832,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079048_9_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:contaminante_medido "Partículas < 2.5 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079048";
   aqm:id_medicion "28079048_9_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00006"^^<xsd:double>;
   aqm:valor_a_las_10 "00005"^^<xsd:double>;
@@ -3871,11 +3870,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079048_10_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 10 μm";
+  aqm:contaminante_medido "Partículas < 10 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079048";
   aqm:id_medicion "28079048_10_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00010"^^<xsd:double>;
   aqm:valor_a_las_10 "00014"^^<xsd:double>;
@@ -3906,11 +3905,11 @@
   a aqm:Contaminante .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079048_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079048";
   aqm:id_medicion "28079048_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00011"^^<xsd:double>;
   aqm:valor_a_las_10 "00078"^^<xsd:double>;
@@ -3945,11 +3944,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079049_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079049";
   aqm:id_medicion "28079049_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00005"^^<xsd:double>;
@@ -3984,11 +3983,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079049_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079049";
   aqm:id_medicion "28079049_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00006"^^<xsd:double>;
   aqm:valor_a_las_10 "00034"^^<xsd:double>;
@@ -4023,11 +4022,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079049_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079049";
   aqm:id_medicion "28079049_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00008"^^<xsd:double>;
   aqm:valor_a_las_10 "00042"^^<xsd:double>;
@@ -4062,11 +4061,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079049_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079049";
   aqm:id_medicion "28079049_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "75.97"^^<xsd:double>;
   aqm:valor_a_las_10 "34.15"^^<xsd:double>;
@@ -4101,11 +4100,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079050_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079050";
   aqm:id_medicion "28079050_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00003"^^<xsd:double>;
   aqm:valor_a_las_10 "00056"^^<xsd:double>;
@@ -4140,11 +4139,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079050_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079050";
   aqm:id_medicion "28079050_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00008"^^<xsd:double>;
   aqm:valor_a_las_10 "00066"^^<xsd:double>;
@@ -4179,11 +4178,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079050_9_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:contaminante_medido "Partículas < 2.5 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079050";
   aqm:id_medicion "28079050_9_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00005"^^<xsd:double>;
   aqm:valor_a_las_10 "00007"^^<xsd:double>;
@@ -4219,11 +4218,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079050_10_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 10 μm";
+  aqm:contaminante_medido "Partículas < 10 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079050";
   aqm:id_medicion "28079050_10_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00013"^^<xsd:double>;
   aqm:valor_a_las_10 "00021"^^<xsd:double>;
@@ -4254,11 +4253,11 @@
   a aqm:Contaminante .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079050_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079050";
   aqm:id_medicion "28079050_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00012"^^<xsd:double>;
   aqm:valor_a_las_10 "00153"^^<xsd:double>;
@@ -4293,11 +4292,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079054_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079054";
   aqm:id_medicion "28079054_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00023"^^<xsd:double>;
@@ -4332,11 +4331,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079054_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079054";
   aqm:id_medicion "28079054_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00016"^^<xsd:double>;
   aqm:valor_a_las_10 "00077"^^<xsd:double>;
@@ -4371,11 +4370,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079054_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079054";
   aqm:id_medicion "28079054_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00018"^^<xsd:double>;
   aqm:valor_a_las_10 "00112"^^<xsd:double>;
@@ -4410,11 +4409,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079054_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079054";
   aqm:id_medicion "28079054_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "71.27"^^<xsd:double>;
   aqm:valor_a_las_10 "19.32"^^<xsd:double>;
@@ -4449,11 +4448,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079055_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079055";
   aqm:id_medicion "28079055_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00003"^^<xsd:double>;
   aqm:valor_a_las_10 "00075"^^<xsd:double>;
@@ -4488,11 +4487,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079055_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079055";
   aqm:id_medicion "28079055_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00043"^^<xsd:double>;
   aqm:valor_a_las_10 "00071"^^<xsd:double>;
@@ -4527,11 +4526,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079055_10_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 10 μm";
+  aqm:contaminante_medido "Partículas < 10 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079055";
   aqm:id_medicion "28079055_10_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00002"^^<xsd:double>;
@@ -4565,11 +4564,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079055_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079055";
   aqm:id_medicion "28079055_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00048"^^<xsd:double>;
   aqm:valor_a_las_10 "00185"^^<xsd:double>;
@@ -4604,11 +4603,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079055_20_59> a aqm:Measurement;
-  aqm:contaminante "Tolueno";
+  aqm:contaminante_medido "Tolueno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079055";
   aqm:id_medicion "28079055_20_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "000.4"^^<xsd:double>;
   aqm:valor_a_las_10 "001.7"^^<xsd:double>;
@@ -4643,11 +4642,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079055_30_59> a aqm:Measurement;
-  aqm:contaminante "Benceno";
+  aqm:contaminante_medido "Benceno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079055";
   aqm:id_medicion "28079055_30_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "000.1"^^<xsd:double>;
   aqm:valor_a_las_10 "000.3"^^<xsd:double>;
@@ -4682,11 +4681,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079055_35_59> a aqm:Measurement;
-  aqm:contaminante "Etilbenceno";
+  aqm:contaminante_medido "Etilbenceno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079055";
   aqm:id_medicion "28079055_35_59";
-  aqm:tecnica "Cromatografía de gases";
+  aqm:tecnica_medicion "Cromatografía de gases";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "000.1"^^<xsd:double>;
   aqm:valor_a_las_10 "000.1"^^<xsd:double>;
@@ -4721,11 +4720,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079055_42_2> a aqm:Measurement;
-  aqm:contaminante "Hidrocarburos totales (hexano)";
+  aqm:contaminante_medido "Hidrocarburos totales (hexano)";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079055";
   aqm:id_medicion "28079055_42_2";
-  aqm:tecnica "Ionización de llama";
+  aqm:tecnica_medicion "Ionización de llama";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "01.53"^^<xsd:double>;
   aqm:valor_a_las_10 "01.85"^^<xsd:double>;
@@ -4759,11 +4758,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q873305" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079055_43_2> a aqm:Measurement;
-  aqm:contaminante "Metano";
+  aqm:contaminante_medido "Metano";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079055";
   aqm:id_medicion "28079055_43_2";
-  aqm:tecnica "Ionización de llama";
+  aqm:tecnica_medicion "Ionización de llama";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "01.39"^^<xsd:double>;
   aqm:valor_a_las_10 "01.60"^^<xsd:double>;
@@ -4799,11 +4798,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q873305" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079055_44_2> a aqm:Measurement;
-  aqm:contaminante "Hidrocarburos no metánicos (hexano)";
+  aqm:contaminante_medido "Hidrocarburos no metánicos (hexano)";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079055";
   aqm:id_medicion "28079055_44_2";
-  aqm:tecnica "Ionización de llama";
+  aqm:tecnica_medicion "Ionización de llama";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "00.13"^^<xsd:double>;
   aqm:valor_a_las_10 "00.24"^^<xsd:double>;
@@ -4834,11 +4833,11 @@
   a aqm:Contaminante .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079056_6_48> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Carbono";
+  aqm:contaminante_medido "Monóxido de Carbono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079056";
   aqm:id_medicion "28079056_6_48";
-  aqm:tecnica "Absorción infrarroja";
+  aqm:tecnica_medicion "Absorción infrarroja";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "000.1"^^<xsd:double>;
   aqm:valor_a_las_10 "000.2"^^<xsd:double>;
@@ -4873,11 +4872,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079056_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079056";
   aqm:id_medicion "28079056_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00006"^^<xsd:double>;
   aqm:valor_a_las_10 "00021"^^<xsd:double>;
@@ -4912,11 +4911,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079056_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079056";
   aqm:id_medicion "28079056_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00018"^^<xsd:double>;
   aqm:valor_a_las_10 "00045"^^<xsd:double>;
@@ -4951,11 +4950,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079056_9_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:contaminante_medido "Partículas < 2.5 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079056";
   aqm:id_medicion "28079056_9_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00005"^^<xsd:double>;
   aqm:valor_a_las_10 "00008"^^<xsd:double>;
@@ -4991,11 +4990,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079056_10_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 10 μm";
+  aqm:contaminante_medido "Partículas < 10 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079056";
   aqm:id_medicion "28079056_10_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00009"^^<xsd:double>;
   aqm:valor_a_las_10 "00014"^^<xsd:double>;
@@ -5026,11 +5025,11 @@
   a aqm:Contaminante .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079056_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079056";
   aqm:id_medicion "28079056_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00027"^^<xsd:double>;
   aqm:valor_a_las_10 "00077"^^<xsd:double>;
@@ -5065,11 +5064,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079056_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079056";
   aqm:id_medicion "28079056_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "72.41"^^<xsd:double>;
   aqm:valor_a_las_10 "37.03"^^<xsd:double>;
@@ -5104,11 +5103,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079057_1_38> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Azufre";
+  aqm:contaminante_medido "Dióxido de Azufre";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079057";
   aqm:id_medicion "28079057_1_38";
-  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:tecnica_medicion "Fluorescencia ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00006"^^<xsd:double>;
   aqm:valor_a_las_10 "00008"^^<xsd:double>;
@@ -5144,11 +5143,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079057_6_48> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Carbono";
+  aqm:contaminante_medido "Monóxido de Carbono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079057";
   aqm:id_medicion "28079057_6_48";
-  aqm:tecnica "Absorción infrarroja";
+  aqm:tecnica_medicion "Absorción infrarroja";
   aqm:unidad "mg/m^3";
   aqm:valor_a_las_1 "000.2"^^<xsd:double>;
   aqm:valor_a_las_10 "000.3"^^<xsd:double>;
@@ -5183,11 +5182,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079057_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079057";
   aqm:id_medicion "28079057_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00014"^^<xsd:double>;
@@ -5222,11 +5221,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079057_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079057";
   aqm:id_medicion "28079057_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00006"^^<xsd:double>;
   aqm:valor_a_las_10 "00050"^^<xsd:double>;
@@ -5261,11 +5260,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079057_10_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 10 μm";
+  aqm:contaminante_medido "Partículas < 10 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079057";
   aqm:id_medicion "28079057_10_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00006"^^<xsd:double>;
   aqm:valor_a_las_10 "00015"^^<xsd:double>;
@@ -5299,11 +5298,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079057_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079057";
   aqm:id_medicion "28079057_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00008"^^<xsd:double>;
   aqm:valor_a_las_10 "00071"^^<xsd:double>;
@@ -5338,11 +5337,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079058_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079058";
   aqm:id_medicion "28079058_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00003"^^<xsd:double>;
@@ -5377,11 +5376,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079058_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079058";
   aqm:id_medicion "28079058_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00004"^^<xsd:double>;
   aqm:valor_a_las_10 "00021"^^<xsd:double>;
@@ -5416,11 +5415,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079058_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079058";
   aqm:id_medicion "28079058_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00005"^^<xsd:double>;
   aqm:valor_a_las_10 "00025"^^<xsd:double>;
@@ -5455,11 +5454,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079058_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079058";
   aqm:id_medicion "28079058_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "86.09"^^<xsd:double>;
   aqm:valor_a_las_10 "50.13"^^<xsd:double>;
@@ -5494,11 +5493,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079059_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079059";
   aqm:id_medicion "28079059_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00029"^^<xsd:double>;
@@ -5533,11 +5532,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079059_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079059";
   aqm:id_medicion "28079059_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00006"^^<xsd:double>;
   aqm:valor_a_las_10 "00064"^^<xsd:double>;
@@ -5572,11 +5571,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079059_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079059";
   aqm:id_medicion "28079059_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00007"^^<xsd:double>;
   aqm:valor_a_las_10 "00109"^^<xsd:double>;
@@ -5611,11 +5610,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079059_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079059";
   aqm:id_medicion "28079059_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "78.17"^^<xsd:double>;
   aqm:valor_a_las_10 "18.61"^^<xsd:double>;
@@ -5650,11 +5649,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079060_7_8> a aqm:Measurement;
-  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:contaminante_medido "Monóxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079060";
   aqm:id_medicion "28079060_7_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00001"^^<xsd:double>;
   aqm:valor_a_las_10 "00006"^^<xsd:double>;
@@ -5689,11 +5688,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079060_8_8> a aqm:Measurement;
-  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:contaminante_medido "Dióxido de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079060";
   aqm:id_medicion "28079060_8_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00009"^^<xsd:double>;
   aqm:valor_a_las_10 "00017"^^<xsd:double>;
@@ -5728,11 +5727,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079060_10_47> a aqm:Measurement;
-  aqm:contaminante "Partículas < 10 μm";
+  aqm:contaminante_medido "Partículas < 10 μm";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079060";
   aqm:id_medicion "28079060_10_47";
-  aqm:tecnica "Microbalanza";
+  aqm:tecnica_medicion "Microbalanza";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00009"^^<xsd:double>;
   aqm:valor_a_las_10 "00011"^^<xsd:double>;
@@ -5766,11 +5765,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079060_12_8> a aqm:Measurement;
-  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:contaminante_medido "Óxidos de Nitrógeno";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079060";
   aqm:id_medicion "28079060_12_8";
-  aqm:tecnica "Quimioluminiscencia";
+  aqm:tecnica_medicion "Quimioluminiscencia";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "00010"^^<xsd:double>;
   aqm:valor_a_las_10 "00027"^^<xsd:double>;
@@ -5805,11 +5804,11 @@
   owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
 
 <http://www.airQualityMadrid.com/resource/Measurement/28079060_14_6> a aqm:Measurement;
-  aqm:contaminante "Ozono";
+  aqm:contaminante_medido "Ozono";
   aqm:fecha "2019-10-2"^^xsd:date;
   aqm:id_estacion "28079060";
   aqm:id_medicion "28079060_14_6";
-  aqm:tecnica "Absorción ultravioleta";
+  aqm:tecnica_medicion "Absorción ultravioleta";
   aqm:unidad "μg/m^3";
   aqm:valor_a_las_1 "91.40"^^<xsd:double>;
   aqm:valor_a_las_10 "47.16"^^<xsd:double>;

--- a/HandsOn/Group15/rdf/rdfDatosEstaciones-with-links.ttl
+++ b/HandsOn/Group15/rdf/rdfDatosEstaciones-with-links.ttl
@@ -1,0 +1,5844 @@
+@prefix geo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix aqm: <http://www.airQualityMadrid.com/ontology#> .
+
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079004_1_38> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Azufre";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079004";
+  aqm:id_medicion "28079004_1_38";
+  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00012"^^<xsd:double>;
+  aqm:valor_a_las_10 "00009"^^<xsd:double>;
+  aqm:valor_a_las_11 "00009"^^<xsd:double>;
+  aqm:valor_a_las_12 "00009"^^<xsd:double>;
+  aqm:valor_a_las_13 "00009"^^<xsd:double>;
+  aqm:valor_a_las_14 "00008"^^<xsd:double>;
+  aqm:valor_a_las_15 "00007"^^<xsd:double>;
+  aqm:valor_a_las_16 "00006"^^<xsd:double>;
+  aqm:valor_a_las_17 "00006"^^<xsd:double>;
+  aqm:valor_a_las_18 "00008"^^<xsd:double>;
+  aqm:valor_a_las_19 "00007"^^<xsd:double>;
+  aqm:valor_a_las_2 "00011"^^<xsd:double>;
+  aqm:valor_a_las_20 "00007"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00008"^^<xsd:double>;
+  aqm:valor_a_las_4 "00009"^^<xsd:double>;
+  aqm:valor_a_las_5 "00011"^^<xsd:double>;
+  aqm:valor_a_las_6 "00008"^^<xsd:double>;
+  aqm:valor_a_las_7 "00008"^^<xsd:double>;
+  aqm:valor_a_las_8 "00009"^^<xsd:double>;
+  aqm:valor_a_las_9 "00009"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Azufre> a
+    aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q5282" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FFluorescencia+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079004_6_48> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Carbono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079004";
+  aqm:id_medicion "28079004_6_48";
+  aqm:tecnica "Absorción infrarroja";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.3"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Carbono>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2025" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+infrarroja> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079004_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079004";
+  aqm:id_medicion "28079004_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00023"^^<xsd:double>;
+  aqm:valor_a_las_11 "00020"^^<xsd:double>;
+  aqm:valor_a_las_12 "00014"^^<xsd:double>;
+  aqm:valor_a_las_13 "00012"^^<xsd:double>;
+  aqm:valor_a_las_14 "00014"^^<xsd:double>;
+  aqm:valor_a_las_15 "00009"^^<xsd:double>;
+  aqm:valor_a_las_16 "00008"^^<xsd:double>;
+  aqm:valor_a_las_17 "00006"^^<xsd:double>;
+  aqm:valor_a_las_18 "00005"^^<xsd:double>;
+  aqm:valor_a_las_19 "00005"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00005"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00002"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00001"^^<xsd:double>;
+  aqm:valor_a_las_8 "00008"^^<xsd:double>;
+  aqm:valor_a_las_9 "00021"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079004_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079004";
+  aqm:id_medicion "28079004_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00013"^^<xsd:double>;
+  aqm:valor_a_las_10 "00057"^^<xsd:double>;
+  aqm:valor_a_las_11 "00041"^^<xsd:double>;
+  aqm:valor_a_las_12 "00031"^^<xsd:double>;
+  aqm:valor_a_las_13 "00026"^^<xsd:double>;
+  aqm:valor_a_las_14 "00029"^^<xsd:double>;
+  aqm:valor_a_las_15 "00023"^^<xsd:double>;
+  aqm:valor_a_las_16 "00020"^^<xsd:double>;
+  aqm:valor_a_las_17 "00018"^^<xsd:double>;
+  aqm:valor_a_las_18 "00021"^^<xsd:double>;
+  aqm:valor_a_las_19 "00023"^^<xsd:double>;
+  aqm:valor_a_las_2 "00007"^^<xsd:double>;
+  aqm:valor_a_las_20 "00026"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00007"^^<xsd:double>;
+  aqm:valor_a_las_4 "00011"^^<xsd:double>;
+  aqm:valor_a_las_5 "00006"^^<xsd:double>;
+  aqm:valor_a_las_6 "00006"^^<xsd:double>;
+  aqm:valor_a_las_7 "00011"^^<xsd:double>;
+  aqm:valor_a_las_8 "00035"^^<xsd:double>;
+  aqm:valor_a_las_9 "00059"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079004_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079004";
+  aqm:id_medicion "28079004_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00015"^^<xsd:double>;
+  aqm:valor_a_las_10 "00092"^^<xsd:double>;
+  aqm:valor_a_las_11 "00071"^^<xsd:double>;
+  aqm:valor_a_las_12 "00052"^^<xsd:double>;
+  aqm:valor_a_las_13 "00044"^^<xsd:double>;
+  aqm:valor_a_las_14 "00050"^^<xsd:double>;
+  aqm:valor_a_las_15 "00037"^^<xsd:double>;
+  aqm:valor_a_las_16 "00033"^^<xsd:double>;
+  aqm:valor_a_las_17 "00027"^^<xsd:double>;
+  aqm:valor_a_las_18 "00029"^^<xsd:double>;
+  aqm:valor_a_las_19 "00031"^^<xsd:double>;
+  aqm:valor_a_las_2 "00009"^^<xsd:double>;
+  aqm:valor_a_las_20 "00033"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00009"^^<xsd:double>;
+  aqm:valor_a_las_4 "00015"^^<xsd:double>;
+  aqm:valor_a_las_5 "00007"^^<xsd:double>;
+  aqm:valor_a_las_6 "00007"^^<xsd:double>;
+  aqm:valor_a_las_7 "00013"^^<xsd:double>;
+  aqm:valor_a_las_8 "00047"^^<xsd:double>;
+  aqm:valor_a_las_9 "00092"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_1_38> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Azufre";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_1_38";
+  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00005"^^<xsd:double>;
+  aqm:valor_a_las_10 "00005"^^<xsd:double>;
+  aqm:valor_a_las_11 "00005"^^<xsd:double>;
+  aqm:valor_a_las_12 "00005"^^<xsd:double>;
+  aqm:valor_a_las_13 "00005"^^<xsd:double>;
+  aqm:valor_a_las_14 "00005"^^<xsd:double>;
+  aqm:valor_a_las_15 "00005"^^<xsd:double>;
+  aqm:valor_a_las_16 "00005"^^<xsd:double>;
+  aqm:valor_a_las_17 "00005"^^<xsd:double>;
+  aqm:valor_a_las_18 "00005"^^<xsd:double>;
+  aqm:valor_a_las_19 "00005"^^<xsd:double>;
+  aqm:valor_a_las_2 "00005"^^<xsd:double>;
+  aqm:valor_a_las_20 "00005"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00005"^^<xsd:double>;
+  aqm:valor_a_las_4 "00005"^^<xsd:double>;
+  aqm:valor_a_las_5 "00005"^^<xsd:double>;
+  aqm:valor_a_las_6 "00005"^^<xsd:double>;
+  aqm:valor_a_las_7 "00005"^^<xsd:double>;
+  aqm:valor_a_las_8 "00005"^^<xsd:double>;
+  aqm:valor_a_las_9 "00005"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Azufre> a
+    aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q5282" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FFluorescencia+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_6_48> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Carbono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_6_48";
+  aqm:tecnica "Absorción infrarroja";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.4"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Carbono>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2025" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+infrarroja> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00002"^^<xsd:double>;
+  aqm:valor_a_las_10 "00024"^^<xsd:double>;
+  aqm:valor_a_las_11 "00014"^^<xsd:double>;
+  aqm:valor_a_las_12 "00005"^^<xsd:double>;
+  aqm:valor_a_las_13 "00004"^^<xsd:double>;
+  aqm:valor_a_las_14 "00011"^^<xsd:double>;
+  aqm:valor_a_las_15 "00008"^^<xsd:double>;
+  aqm:valor_a_las_16 "00004"^^<xsd:double>;
+  aqm:valor_a_las_17 "00005"^^<xsd:double>;
+  aqm:valor_a_las_18 "00006"^^<xsd:double>;
+  aqm:valor_a_las_19 "00006"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00006"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00002"^^<xsd:double>;
+  aqm:valor_a_las_7 "00003"^^<xsd:double>;
+  aqm:valor_a_las_8 "00011"^^<xsd:double>;
+  aqm:valor_a_las_9 "00015"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00017"^^<xsd:double>;
+  aqm:valor_a_las_10 "00057"^^<xsd:double>;
+  aqm:valor_a_las_11 "00055"^^<xsd:double>;
+  aqm:valor_a_las_12 "00050"^^<xsd:double>;
+  aqm:valor_a_las_13 "00044"^^<xsd:double>;
+  aqm:valor_a_las_14 "00033"^^<xsd:double>;
+  aqm:valor_a_las_15 "00030"^^<xsd:double>;
+  aqm:valor_a_las_16 "00022"^^<xsd:double>;
+  aqm:valor_a_las_17 "00024"^^<xsd:double>;
+  aqm:valor_a_las_18 "00032"^^<xsd:double>;
+  aqm:valor_a_las_19 "00040"^^<xsd:double>;
+  aqm:valor_a_las_2 "00013"^^<xsd:double>;
+  aqm:valor_a_las_20 "00054"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00011"^^<xsd:double>;
+  aqm:valor_a_las_4 "00010"^^<xsd:double>;
+  aqm:valor_a_las_5 "00007"^^<xsd:double>;
+  aqm:valor_a_las_6 "00010"^^<xsd:double>;
+  aqm:valor_a_las_7 "00021"^^<xsd:double>;
+  aqm:valor_a_las_8 "00054"^^<xsd:double>;
+  aqm:valor_a_las_9 "00060"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_9_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_9_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00006"^^<xsd:double>;
+  aqm:valor_a_las_10 "00011"^^<xsd:double>;
+  aqm:valor_a_las_11 "00014"^^<xsd:double>;
+  aqm:valor_a_las_12 "00000"^^<xsd:double>;
+  aqm:valor_a_las_13 "00001"^^<xsd:double>;
+  aqm:valor_a_las_14 "00001"^^<xsd:double>;
+  aqm:valor_a_las_15 "00005"^^<xsd:double>;
+  aqm:valor_a_las_16 "00004"^^<xsd:double>;
+  aqm:valor_a_las_17 "00003"^^<xsd:double>;
+  aqm:valor_a_las_18 "00007"^^<xsd:double>;
+  aqm:valor_a_las_19 "00009"^^<xsd:double>;
+  aqm:valor_a_las_2 "00009"^^<xsd:double>;
+  aqm:valor_a_las_20 "00011"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00005"^^<xsd:double>;
+  aqm:valor_a_las_4 "00004"^^<xsd:double>;
+  aqm:valor_a_las_5 "00004"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00005"^^<xsd:double>;
+  aqm:valor_a_las_8 "00004"^^<xsd:double>;
+  aqm:valor_a_las_9 "00001"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+2.5+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Microbalanza> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_10_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 10 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_10_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00013"^^<xsd:double>;
+  aqm:valor_a_las_10 "00022"^^<xsd:double>;
+  aqm:valor_a_las_11 "00028"^^<xsd:double>;
+  aqm:valor_a_las_12 "00000"^^<xsd:double>;
+  aqm:valor_a_las_13 "00001"^^<xsd:double>;
+  aqm:valor_a_las_14 "00001"^^<xsd:double>;
+  aqm:valor_a_las_15 "00008"^^<xsd:double>;
+  aqm:valor_a_las_16 "00011"^^<xsd:double>;
+  aqm:valor_a_las_17 "00010"^^<xsd:double>;
+  aqm:valor_a_las_18 "00016"^^<xsd:double>;
+  aqm:valor_a_las_19 "00016"^^<xsd:double>;
+  aqm:valor_a_las_2 "00016"^^<xsd:double>;
+  aqm:valor_a_las_20 "00017"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00008"^^<xsd:double>;
+  aqm:valor_a_las_4 "00010"^^<xsd:double>;
+  aqm:valor_a_las_5 "00012"^^<xsd:double>;
+  aqm:valor_a_las_6 "00003"^^<xsd:double>;
+  aqm:valor_a_las_7 "00010"^^<xsd:double>;
+  aqm:valor_a_las_8 "00011"^^<xsd:double>;
+  aqm:valor_a_las_9 "00011"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+10+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00020"^^<xsd:double>;
+  aqm:valor_a_las_10 "00094"^^<xsd:double>;
+  aqm:valor_a_las_11 "00075"^^<xsd:double>;
+  aqm:valor_a_las_12 "00058"^^<xsd:double>;
+  aqm:valor_a_las_13 "00050"^^<xsd:double>;
+  aqm:valor_a_las_14 "00050"^^<xsd:double>;
+  aqm:valor_a_las_15 "00043"^^<xsd:double>;
+  aqm:valor_a_las_16 "00028"^^<xsd:double>;
+  aqm:valor_a_las_17 "00032"^^<xsd:double>;
+  aqm:valor_a_las_18 "00042"^^<xsd:double>;
+  aqm:valor_a_las_19 "00050"^^<xsd:double>;
+  aqm:valor_a_las_2 "00014"^^<xsd:double>;
+  aqm:valor_a_las_20 "00063"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00013"^^<xsd:double>;
+  aqm:valor_a_las_4 "00012"^^<xsd:double>;
+  aqm:valor_a_las_5 "00008"^^<xsd:double>;
+  aqm:valor_a_las_6 "00013"^^<xsd:double>;
+  aqm:valor_a_las_7 "00025"^^<xsd:double>;
+  aqm:valor_a_las_8 "00071"^^<xsd:double>;
+  aqm:valor_a_las_9 "00083"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "68.97"^^<xsd:double>;
+  aqm:valor_a_las_10 "26.21"^^<xsd:double>;
+  aqm:valor_a_las_11 "14.00"^^<xsd:double>;
+  aqm:valor_a_las_12 "05.74"^^<xsd:double>;
+  aqm:valor_a_las_13 "18.64"^^<xsd:double>;
+  aqm:valor_a_las_14 "59.67"^^<xsd:double>;
+  aqm:valor_a_las_15 "68.61"^^<xsd:double>;
+  aqm:valor_a_las_16 "79.14"^^<xsd:double>;
+  aqm:valor_a_las_17 "79.61"^^<xsd:double>;
+  aqm:valor_a_las_18 "70.37"^^<xsd:double>;
+  aqm:valor_a_las_19 "62.13"^^<xsd:double>;
+  aqm:valor_a_las_2 "74.19"^^<xsd:double>;
+  aqm:valor_a_las_20 "46.58"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "68.78"^^<xsd:double>;
+  aqm:valor_a_las_4 "69.92"^^<xsd:double>;
+  aqm:valor_a_las_5 "70.49"^^<xsd:double>;
+  aqm:valor_a_las_6 "66.33"^^<xsd:double>;
+  aqm:valor_a_las_7 "55.68"^^<xsd:double>;
+  aqm:valor_a_las_8 "27.62"^^<xsd:double>;
+  aqm:valor_a_las_9 "22.74"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_20_59> a aqm:Measurement;
+  aqm:contaminante "Tolueno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_20_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "002.1"^^<xsd:double>;
+  aqm:valor_a_las_10 "004.7"^^<xsd:double>;
+  aqm:valor_a_las_11 "006.8"^^<xsd:double>;
+  aqm:valor_a_las_12 "005.4"^^<xsd:double>;
+  aqm:valor_a_las_13 "004.9"^^<xsd:double>;
+  aqm:valor_a_las_14 "002.6"^^<xsd:double>;
+  aqm:valor_a_las_15 "002.9"^^<xsd:double>;
+  aqm:valor_a_las_16 "002.3"^^<xsd:double>;
+  aqm:valor_a_las_17 "002.2"^^<xsd:double>;
+  aqm:valor_a_las_18 "003.0"^^<xsd:double>;
+  aqm:valor_a_las_19 "002.9"^^<xsd:double>;
+  aqm:valor_a_las_2 "001.6"^^<xsd:double>;
+  aqm:valor_a_las_20 "003.0"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "001.2"^^<xsd:double>;
+  aqm:valor_a_las_4 "001.2"^^<xsd:double>;
+  aqm:valor_a_las_5 "001.0"^^<xsd:double>;
+  aqm:valor_a_las_6 "001.0"^^<xsd:double>;
+  aqm:valor_a_las_7 "001.0"^^<xsd:double>;
+  aqm:valor_a_las_8 "001.5"^^<xsd:double>;
+  aqm:valor_a_las_9 "002.7"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Tolueno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q15779" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FCromatograf%C3%ADa+de+gases> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_30_59> a aqm:Measurement;
+  aqm:contaminante "Benceno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_30_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "000.5"^^<xsd:double>;
+  aqm:valor_a_las_10 "001.0"^^<xsd:double>;
+  aqm:valor_a_las_11 "001.0"^^<xsd:double>;
+  aqm:valor_a_las_12 "001.0"^^<xsd:double>;
+  aqm:valor_a_las_13 "001.0"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.5"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.6"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.5"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.5"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.5"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.5"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.7"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.6"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Benceno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2270" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_35_59> a aqm:Measurement;
+  aqm:contaminante "Etilbenceno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_35_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "004.2"^^<xsd:double>;
+  aqm:valor_a_las_10 "002.8"^^<xsd:double>;
+  aqm:valor_a_las_11 "004.1"^^<xsd:double>;
+  aqm:valor_a_las_12 "012.4"^^<xsd:double>;
+  aqm:valor_a_las_13 "013.4"^^<xsd:double>;
+  aqm:valor_a_las_14 "005.1"^^<xsd:double>;
+  aqm:valor_a_las_15 "002.6"^^<xsd:double>;
+  aqm:valor_a_las_16 "003.3"^^<xsd:double>;
+  aqm:valor_a_las_17 "004.1"^^<xsd:double>;
+  aqm:valor_a_las_18 "004.4"^^<xsd:double>;
+  aqm:valor_a_las_19 "004.5"^^<xsd:double>;
+  aqm:valor_a_las_2 "003.1"^^<xsd:double>;
+  aqm:valor_a_las_20 "004.4"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "003.0"^^<xsd:double>;
+  aqm:valor_a_las_4 "003.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "002.8"^^<xsd:double>;
+  aqm:valor_a_las_6 "002.5"^^<xsd:double>;
+  aqm:valor_a_las_7 "002.4"^^<xsd:double>;
+  aqm:valor_a_las_8 "002.4"^^<xsd:double>;
+  aqm:valor_a_las_9 "002.6"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Etilbenceno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q409184" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_42_2> a aqm:Measurement;
+  aqm:contaminante "Hidrocarburos totales (hexano)";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_42_2";
+  aqm:tecnica "Ionización de llama";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "01.60"^^<xsd:double>;
+  aqm:valor_a_las_10 "01.65"^^<xsd:double>;
+  aqm:valor_a_las_11 "01.70"^^<xsd:double>;
+  aqm:valor_a_las_12 "-0.01"^^<xsd:double>;
+  aqm:valor_a_las_13 "00.25"^^<xsd:double>;
+  aqm:valor_a_las_14 "01.58"^^<xsd:double>;
+  aqm:valor_a_las_15 "01.61"^^<xsd:double>;
+  aqm:valor_a_las_16 "01.64"^^<xsd:double>;
+  aqm:valor_a_las_17 "01.65"^^<xsd:double>;
+  aqm:valor_a_las_18 "01.66"^^<xsd:double>;
+  aqm:valor_a_las_19 "01.64"^^<xsd:double>;
+  aqm:valor_a_las_2 "01.58"^^<xsd:double>;
+  aqm:valor_a_las_20 "01.65"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "01.57"^^<xsd:double>;
+  aqm:valor_a_las_4 "01.57"^^<xsd:double>;
+  aqm:valor_a_las_5 "01.56"^^<xsd:double>;
+  aqm:valor_a_las_6 "01.58"^^<xsd:double>;
+  aqm:valor_a_las_7 "01.58"^^<xsd:double>;
+  aqm:valor_a_las_8 "01.59"^^<xsd:double>;
+  aqm:valor_a_las_9 "01.62"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FHidrocarburos+totales+%28hexano%29>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FIonizaci%C3%B3n+de+llama> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q873305" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_43_2> a aqm:Measurement;
+  aqm:contaminante "Metano";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_43_2";
+  aqm:tecnica "Ionización de llama";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "01.48"^^<xsd:double>;
+  aqm:valor_a_las_10 "01.49"^^<xsd:double>;
+  aqm:valor_a_las_11 "01.49"^^<xsd:double>;
+  aqm:valor_a_las_12 "-0.05"^^<xsd:double>;
+  aqm:valor_a_las_13 "00.22"^^<xsd:double>;
+  aqm:valor_a_las_14 "01.49"^^<xsd:double>;
+  aqm:valor_a_las_15 "01.47"^^<xsd:double>;
+  aqm:valor_a_las_16 "01.47"^^<xsd:double>;
+  aqm:valor_a_las_17 "01.47"^^<xsd:double>;
+  aqm:valor_a_las_18 "01.47"^^<xsd:double>;
+  aqm:valor_a_las_19 "01.47"^^<xsd:double>;
+  aqm:valor_a_las_2 "01.47"^^<xsd:double>;
+  aqm:valor_a_las_20 "01.48"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "01.47"^^<xsd:double>;
+  aqm:valor_a_las_4 "01.47"^^<xsd:double>;
+  aqm:valor_a_las_5 "01.47"^^<xsd:double>;
+  aqm:valor_a_las_6 "01.47"^^<xsd:double>;
+  aqm:valor_a_las_7 "01.48"^^<xsd:double>;
+  aqm:valor_a_las_8 "01.48"^^<xsd:double>;
+  aqm:valor_a_las_9 "01.49"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Metano> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q37129" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079008_44_2> a aqm:Measurement;
+  aqm:contaminante "Hidrocarburos no metánicos (hexano)";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079008";
+  aqm:id_medicion "28079008_44_2";
+  aqm:tecnica "Ionización de llama";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "00.12"^^<xsd:double>;
+  aqm:valor_a_las_10 "00.17"^^<xsd:double>;
+  aqm:valor_a_las_11 "00.21"^^<xsd:double>;
+  aqm:valor_a_las_12 "00.04"^^<xsd:double>;
+  aqm:valor_a_las_13 "00.04"^^<xsd:double>;
+  aqm:valor_a_las_14 "00.09"^^<xsd:double>;
+  aqm:valor_a_las_15 "00.14"^^<xsd:double>;
+  aqm:valor_a_las_16 "00.17"^^<xsd:double>;
+  aqm:valor_a_las_17 "00.19"^^<xsd:double>;
+  aqm:valor_a_las_18 "00.19"^^<xsd:double>;
+  aqm:valor_a_las_19 "00.17"^^<xsd:double>;
+  aqm:valor_a_las_2 "00.11"^^<xsd:double>;
+  aqm:valor_a_las_20 "00.18"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00.10"^^<xsd:double>;
+  aqm:valor_a_las_4 "00.10"^^<xsd:double>;
+  aqm:valor_a_las_5 "00.09"^^<xsd:double>;
+  aqm:valor_a_las_6 "00.11"^^<xsd:double>;
+  aqm:valor_a_las_7 "00.10"^^<xsd:double>;
+  aqm:valor_a_las_8 "00.11"^^<xsd:double>;
+  aqm:valor_a_las_9 "00.14"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FHidrocarburos+no+met%C3%A1nicos+%28hexano%29>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079011_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079011";
+  aqm:id_medicion "28079011_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00043"^^<xsd:double>;
+  aqm:valor_a_las_11 "00015"^^<xsd:double>;
+  aqm:valor_a_las_12 "00008"^^<xsd:double>;
+  aqm:valor_a_las_13 "00014"^^<xsd:double>;
+  aqm:valor_a_las_14 "00011"^^<xsd:double>;
+  aqm:valor_a_las_15 "00014"^^<xsd:double>;
+  aqm:valor_a_las_16 "00005"^^<xsd:double>;
+  aqm:valor_a_las_17 "00011"^^<xsd:double>;
+  aqm:valor_a_las_18 "00014"^^<xsd:double>;
+  aqm:valor_a_las_19 "00005"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00001"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00002"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00003"^^<xsd:double>;
+  aqm:valor_a_las_8 "00012"^^<xsd:double>;
+  aqm:valor_a_las_9 "00037"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079011_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079011";
+  aqm:id_medicion "28079011_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00013"^^<xsd:double>;
+  aqm:valor_a_las_10 "00075"^^<xsd:double>;
+  aqm:valor_a_las_11 "00035"^^<xsd:double>;
+  aqm:valor_a_las_12 "00028"^^<xsd:double>;
+  aqm:valor_a_las_13 "00032"^^<xsd:double>;
+  aqm:valor_a_las_14 "00029"^^<xsd:double>;
+  aqm:valor_a_las_15 "00032"^^<xsd:double>;
+  aqm:valor_a_las_16 "00019"^^<xsd:double>;
+  aqm:valor_a_las_17 "00029"^^<xsd:double>;
+  aqm:valor_a_las_18 "00031"^^<xsd:double>;
+  aqm:valor_a_las_19 "00024"^^<xsd:double>;
+  aqm:valor_a_las_2 "00010"^^<xsd:double>;
+  aqm:valor_a_las_20 "00029"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00007"^^<xsd:double>;
+  aqm:valor_a_las_4 "00005"^^<xsd:double>;
+  aqm:valor_a_las_5 "00005"^^<xsd:double>;
+  aqm:valor_a_las_6 "00006"^^<xsd:double>;
+  aqm:valor_a_las_7 "00016"^^<xsd:double>;
+  aqm:valor_a_las_8 "00037"^^<xsd:double>;
+  aqm:valor_a_las_9 "00072"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079011_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079011";
+  aqm:id_medicion "28079011_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00015"^^<xsd:double>;
+  aqm:valor_a_las_10 "00141"^^<xsd:double>;
+  aqm:valor_a_las_11 "00059"^^<xsd:double>;
+  aqm:valor_a_las_12 "00040"^^<xsd:double>;
+  aqm:valor_a_las_13 "00054"^^<xsd:double>;
+  aqm:valor_a_las_14 "00046"^^<xsd:double>;
+  aqm:valor_a_las_15 "00053"^^<xsd:double>;
+  aqm:valor_a_las_16 "00027"^^<xsd:double>;
+  aqm:valor_a_las_17 "00045"^^<xsd:double>;
+  aqm:valor_a_las_18 "00052"^^<xsd:double>;
+  aqm:valor_a_las_19 "00031"^^<xsd:double>;
+  aqm:valor_a_las_2 "00011"^^<xsd:double>;
+  aqm:valor_a_las_20 "00031"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00009"^^<xsd:double>;
+  aqm:valor_a_las_4 "00006"^^<xsd:double>;
+  aqm:valor_a_las_5 "00008"^^<xsd:double>;
+  aqm:valor_a_las_6 "00008"^^<xsd:double>;
+  aqm:valor_a_las_7 "00021"^^<xsd:double>;
+  aqm:valor_a_las_8 "00056"^^<xsd:double>;
+  aqm:valor_a_las_9 "00128"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079011_20_59> a aqm:Measurement;
+  aqm:contaminante "Tolueno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079011";
+  aqm:id_medicion "28079011_20_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "001.0"^^<xsd:double>;
+  aqm:valor_a_las_10 "005.8"^^<xsd:double>;
+  aqm:valor_a_las_11 "003.6"^^<xsd:double>;
+  aqm:valor_a_las_12 "001.9"^^<xsd:double>;
+  aqm:valor_a_las_13 "001.4"^^<xsd:double>;
+  aqm:valor_a_las_14 "001.9"^^<xsd:double>;
+  aqm:valor_a_las_15 "002.8"^^<xsd:double>;
+  aqm:valor_a_las_16 "001.5"^^<xsd:double>;
+  aqm:valor_a_las_17 "001.7"^^<xsd:double>;
+  aqm:valor_a_las_18 "002.2"^^<xsd:double>;
+  aqm:valor_a_las_19 "001.3"^^<xsd:double>;
+  aqm:valor_a_las_2 "001.0"^^<xsd:double>;
+  aqm:valor_a_las_20 "001.1"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.7"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.9"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.9"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.6"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.6"^^<xsd:double>;
+  aqm:valor_a_las_8 "001.2"^^<xsd:double>;
+  aqm:valor_a_las_9 "004.0"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Tolueno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q15779" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FCromatograf%C3%ADa+de+gases> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079011_30_59> a aqm:Measurement;
+  aqm:contaminante "Benceno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079011";
+  aqm:id_medicion "28079011_30_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.4"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Benceno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2270" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079011_35_59> a aqm:Measurement;
+  aqm:contaminante "Etilbenceno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079011";
+  aqm:id_medicion "28079011_35_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.5"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.3"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Etilbenceno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q409184" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079016_6_48> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Carbono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079016";
+  aqm:id_medicion "28079016_6_48";
+  aqm:tecnica "Absorción infrarroja";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.3"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Carbono>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2025" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+infrarroja> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079016_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079016";
+  aqm:id_medicion "28079016_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00020"^^<xsd:double>;
+  aqm:valor_a_las_11 "00004"^^<xsd:double>;
+  aqm:valor_a_las_12 "00005"^^<xsd:double>;
+  aqm:valor_a_las_13 "00005"^^<xsd:double>;
+  aqm:valor_a_las_14 "00003"^^<xsd:double>;
+  aqm:valor_a_las_15 "00003"^^<xsd:double>;
+  aqm:valor_a_las_16 "00001"^^<xsd:double>;
+  aqm:valor_a_las_17 "00002"^^<xsd:double>;
+  aqm:valor_a_las_18 "00001"^^<xsd:double>;
+  aqm:valor_a_las_19 "00004"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00001"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00001"^^<xsd:double>;
+  aqm:valor_a_las_8 "00008"^^<xsd:double>;
+  aqm:valor_a_las_9 "00012"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079016_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079016";
+  aqm:id_medicion "28079016_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00009"^^<xsd:double>;
+  aqm:valor_a_las_10 "00068"^^<xsd:double>;
+  aqm:valor_a_las_11 "00024"^^<xsd:double>;
+  aqm:valor_a_las_12 "00024"^^<xsd:double>;
+  aqm:valor_a_las_13 "00015"^^<xsd:double>;
+  aqm:valor_a_las_14 "00011"^^<xsd:double>;
+  aqm:valor_a_las_15 "00012"^^<xsd:double>;
+  aqm:valor_a_las_16 "00009"^^<xsd:double>;
+  aqm:valor_a_las_17 "00008"^^<xsd:double>;
+  aqm:valor_a_las_18 "00007"^^<xsd:double>;
+  aqm:valor_a_las_19 "00015"^^<xsd:double>;
+  aqm:valor_a_las_2 "00004"^^<xsd:double>;
+  aqm:valor_a_las_20 "00027"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00003"^^<xsd:double>;
+  aqm:valor_a_las_4 "00003"^^<xsd:double>;
+  aqm:valor_a_las_5 "00003"^^<xsd:double>;
+  aqm:valor_a_las_6 "00004"^^<xsd:double>;
+  aqm:valor_a_las_7 "00014"^^<xsd:double>;
+  aqm:valor_a_las_8 "00038"^^<xsd:double>;
+  aqm:valor_a_las_9 "00060"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079016_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079016";
+  aqm:id_medicion "28079016_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00010"^^<xsd:double>;
+  aqm:valor_a_las_10 "00099"^^<xsd:double>;
+  aqm:valor_a_las_11 "00030"^^<xsd:double>;
+  aqm:valor_a_las_12 "00031"^^<xsd:double>;
+  aqm:valor_a_las_13 "00022"^^<xsd:double>;
+  aqm:valor_a_las_14 "00015"^^<xsd:double>;
+  aqm:valor_a_las_15 "00017"^^<xsd:double>;
+  aqm:valor_a_las_16 "00011"^^<xsd:double>;
+  aqm:valor_a_las_17 "00011"^^<xsd:double>;
+  aqm:valor_a_las_18 "00009"^^<xsd:double>;
+  aqm:valor_a_las_19 "00022"^^<xsd:double>;
+  aqm:valor_a_las_2 "00006"^^<xsd:double>;
+  aqm:valor_a_las_20 "00028"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00005"^^<xsd:double>;
+  aqm:valor_a_las_4 "00005"^^<xsd:double>;
+  aqm:valor_a_las_5 "00004"^^<xsd:double>;
+  aqm:valor_a_las_6 "00005"^^<xsd:double>;
+  aqm:valor_a_las_7 "00016"^^<xsd:double>;
+  aqm:valor_a_las_8 "00051"^^<xsd:double>;
+  aqm:valor_a_las_9 "00078"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079016_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079016";
+  aqm:id_medicion "28079016_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "46.65"^^<xsd:double>;
+  aqm:valor_a_las_10 "03.99"^^<xsd:double>;
+  aqm:valor_a_las_11 "19.51"^^<xsd:double>;
+  aqm:valor_a_las_12 "29.00"^^<xsd:double>;
+  aqm:valor_a_las_13 "37.82"^^<xsd:double>;
+  aqm:valor_a_las_14 "45.47"^^<xsd:double>;
+  aqm:valor_a_las_15 "49.78"^^<xsd:double>;
+  aqm:valor_a_las_16 "53.30"^^<xsd:double>;
+  aqm:valor_a_las_17 "56.09"^^<xsd:double>;
+  aqm:valor_a_las_18 "57.27"^^<xsd:double>;
+  aqm:valor_a_las_19 "50.29"^^<xsd:double>;
+  aqm:valor_a_las_2 "55.48"^^<xsd:double>;
+  aqm:valor_a_las_20 "39.78"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "51.16"^^<xsd:double>;
+  aqm:valor_a_las_4 "50.13"^^<xsd:double>;
+  aqm:valor_a_las_5 "52.24"^^<xsd:double>;
+  aqm:valor_a_las_6 "51.10"^^<xsd:double>;
+  aqm:valor_a_las_7 "45.85"^^<xsd:double>;
+  aqm:valor_a_las_8 "28.89"^^<xsd:double>;
+  aqm:valor_a_las_9 "08.41"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079017_1_38> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Azufre";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079017";
+  aqm:id_medicion "28079017_1_38";
+  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00009"^^<xsd:double>;
+  aqm:valor_a_las_10 "00010"^^<xsd:double>;
+  aqm:valor_a_las_11 "00009"^^<xsd:double>;
+  aqm:valor_a_las_12 "00010"^^<xsd:double>;
+  aqm:valor_a_las_13 "00008"^^<xsd:double>;
+  aqm:valor_a_las_14 "00008"^^<xsd:double>;
+  aqm:valor_a_las_15 "00007"^^<xsd:double>;
+  aqm:valor_a_las_16 "00006"^^<xsd:double>;
+  aqm:valor_a_las_17 "00004"^^<xsd:double>;
+  aqm:valor_a_las_18 "00005"^^<xsd:double>;
+  aqm:valor_a_las_19 "00005"^^<xsd:double>;
+  aqm:valor_a_las_2 "00009"^^<xsd:double>;
+  aqm:valor_a_las_20 "00006"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00009"^^<xsd:double>;
+  aqm:valor_a_las_4 "00009"^^<xsd:double>;
+  aqm:valor_a_las_5 "00009"^^<xsd:double>;
+  aqm:valor_a_las_6 "00010"^^<xsd:double>;
+  aqm:valor_a_las_7 "00009"^^<xsd:double>;
+  aqm:valor_a_las_8 "00009"^^<xsd:double>;
+  aqm:valor_a_las_9 "00010"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Azufre> a
+    aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q5282" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FFluorescencia+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079017_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079017";
+  aqm:id_medicion "28079017_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00002"^^<xsd:double>;
+  aqm:valor_a_las_10 "00010"^^<xsd:double>;
+  aqm:valor_a_las_11 "00009"^^<xsd:double>;
+  aqm:valor_a_las_12 "00011"^^<xsd:double>;
+  aqm:valor_a_las_13 "00012"^^<xsd:double>;
+  aqm:valor_a_las_14 "00006"^^<xsd:double>;
+  aqm:valor_a_las_15 "00006"^^<xsd:double>;
+  aqm:valor_a_las_16 "00004"^^<xsd:double>;
+  aqm:valor_a_las_17 "00004"^^<xsd:double>;
+  aqm:valor_a_las_18 "00004"^^<xsd:double>;
+  aqm:valor_a_las_19 "00003"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00002"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00002"^^<xsd:double>;
+  aqm:valor_a_las_7 "00003"^^<xsd:double>;
+  aqm:valor_a_las_8 "00006"^^<xsd:double>;
+  aqm:valor_a_las_9 "00013"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079017_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079017";
+  aqm:id_medicion "28079017_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00013"^^<xsd:double>;
+  aqm:valor_a_las_10 "00036"^^<xsd:double>;
+  aqm:valor_a_las_11 "00029"^^<xsd:double>;
+  aqm:valor_a_las_12 "00031"^^<xsd:double>;
+  aqm:valor_a_las_13 "00039"^^<xsd:double>;
+  aqm:valor_a_las_14 "00022"^^<xsd:double>;
+  aqm:valor_a_las_15 "00022"^^<xsd:double>;
+  aqm:valor_a_las_16 "00020"^^<xsd:double>;
+  aqm:valor_a_las_17 "00020"^^<xsd:double>;
+  aqm:valor_a_las_18 "00021"^^<xsd:double>;
+  aqm:valor_a_las_19 "00020"^^<xsd:double>;
+  aqm:valor_a_las_2 "00009"^^<xsd:double>;
+  aqm:valor_a_las_20 "00028"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00006"^^<xsd:double>;
+  aqm:valor_a_las_4 "00006"^^<xsd:double>;
+  aqm:valor_a_las_5 "00006"^^<xsd:double>;
+  aqm:valor_a_las_6 "00009"^^<xsd:double>;
+  aqm:valor_a_las_7 "00017"^^<xsd:double>;
+  aqm:valor_a_las_8 "00033"^^<xsd:double>;
+  aqm:valor_a_las_9 "00041"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079017_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079017";
+  aqm:id_medicion "28079017_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00016"^^<xsd:double>;
+  aqm:valor_a_las_10 "00052"^^<xsd:double>;
+  aqm:valor_a_las_11 "00043"^^<xsd:double>;
+  aqm:valor_a_las_12 "00048"^^<xsd:double>;
+  aqm:valor_a_las_13 "00056"^^<xsd:double>;
+  aqm:valor_a_las_14 "00032"^^<xsd:double>;
+  aqm:valor_a_las_15 "00031"^^<xsd:double>;
+  aqm:valor_a_las_16 "00027"^^<xsd:double>;
+  aqm:valor_a_las_17 "00026"^^<xsd:double>;
+  aqm:valor_a_las_18 "00028"^^<xsd:double>;
+  aqm:valor_a_las_19 "00024"^^<xsd:double>;
+  aqm:valor_a_las_2 "00011"^^<xsd:double>;
+  aqm:valor_a_las_20 "00031"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00008"^^<xsd:double>;
+  aqm:valor_a_las_4 "00007"^^<xsd:double>;
+  aqm:valor_a_las_5 "00008"^^<xsd:double>;
+  aqm:valor_a_las_6 "00012"^^<xsd:double>;
+  aqm:valor_a_las_7 "00022"^^<xsd:double>;
+  aqm:valor_a_las_8 "00041"^^<xsd:double>;
+  aqm:valor_a_las_9 "00061"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079017_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079017";
+  aqm:id_medicion "28079017_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "64.59"^^<xsd:double>;
+  aqm:valor_a_las_10 "36.56"^^<xsd:double>;
+  aqm:valor_a_las_11 "41.16"^^<xsd:double>;
+  aqm:valor_a_las_12 "39.52"^^<xsd:double>;
+  aqm:valor_a_las_13 "39.88"^^<xsd:double>;
+  aqm:valor_a_las_14 "00000"^^<xsd:double>;
+  aqm:valor_a_las_15 "66.49"^^<xsd:double>;
+  aqm:valor_a_las_16 "72.46"^^<xsd:double>;
+  aqm:valor_a_las_17 "77.48"^^<xsd:double>;
+  aqm:valor_a_las_18 "75.98"^^<xsd:double>;
+  aqm:valor_a_las_19 "74.55"^^<xsd:double>;
+  aqm:valor_a_las_2 "70.99"^^<xsd:double>;
+  aqm:valor_a_las_20 "61.00"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "71.39"^^<xsd:double>;
+  aqm:valor_a_las_4 "71.24"^^<xsd:double>;
+  aqm:valor_a_las_5 "64.42"^^<xsd:double>;
+  aqm:valor_a_las_6 "60.33"^^<xsd:double>;
+  aqm:valor_a_las_7 "54.63"^^<xsd:double>;
+  aqm:valor_a_las_8 "40.38"^^<xsd:double>;
+  aqm:valor_a_las_9 "32.54"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079018_1_38> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Azufre";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079018";
+  aqm:id_medicion "28079018_1_38";
+  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00006"^^<xsd:double>;
+  aqm:valor_a_las_10 "00006"^^<xsd:double>;
+  aqm:valor_a_las_11 "00006"^^<xsd:double>;
+  aqm:valor_a_las_12 "00009"^^<xsd:double>;
+  aqm:valor_a_las_13 "00011"^^<xsd:double>;
+  aqm:valor_a_las_14 "00012"^^<xsd:double>;
+  aqm:valor_a_las_15 "00013"^^<xsd:double>;
+  aqm:valor_a_las_16 "00012"^^<xsd:double>;
+  aqm:valor_a_las_17 "00010"^^<xsd:double>;
+  aqm:valor_a_las_18 "00009"^^<xsd:double>;
+  aqm:valor_a_las_19 "00008"^^<xsd:double>;
+  aqm:valor_a_las_2 "00006"^^<xsd:double>;
+  aqm:valor_a_las_20 "00007"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00006"^^<xsd:double>;
+  aqm:valor_a_las_4 "00005"^^<xsd:double>;
+  aqm:valor_a_las_5 "00006"^^<xsd:double>;
+  aqm:valor_a_las_6 "00006"^^<xsd:double>;
+  aqm:valor_a_las_7 "00006"^^<xsd:double>;
+  aqm:valor_a_las_8 "00006"^^<xsd:double>;
+  aqm:valor_a_las_9 "00005"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Azufre> a
+    aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q5282" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FFluorescencia+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079018_6_48> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Carbono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079018";
+  aqm:id_medicion "28079018_6_48";
+  aqm:tecnica "Absorción infrarroja";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.5"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.4"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Carbono>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2025" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+infrarroja> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079018_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079018";
+  aqm:id_medicion "28079018_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00006"^^<xsd:double>;
+  aqm:valor_a_las_11 "00007"^^<xsd:double>;
+  aqm:valor_a_las_12 "00010"^^<xsd:double>;
+  aqm:valor_a_las_13 "00014"^^<xsd:double>;
+  aqm:valor_a_las_14 "00006"^^<xsd:double>;
+  aqm:valor_a_las_15 "00005"^^<xsd:double>;
+  aqm:valor_a_las_16 "00003"^^<xsd:double>;
+  aqm:valor_a_las_17 "00003"^^<xsd:double>;
+  aqm:valor_a_las_18 "00002"^^<xsd:double>;
+  aqm:valor_a_las_19 "00002"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00003"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00002"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00001"^^<xsd:double>;
+  aqm:valor_a_las_8 "00002"^^<xsd:double>;
+  aqm:valor_a_las_9 "00005"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079018_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079018";
+  aqm:id_medicion "28079018_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00010"^^<xsd:double>;
+  aqm:valor_a_las_10 "00028"^^<xsd:double>;
+  aqm:valor_a_las_11 "00027"^^<xsd:double>;
+  aqm:valor_a_las_12 "00026"^^<xsd:double>;
+  aqm:valor_a_las_13 "00029"^^<xsd:double>;
+  aqm:valor_a_las_14 "00020"^^<xsd:double>;
+  aqm:valor_a_las_15 "00019"^^<xsd:double>;
+  aqm:valor_a_las_16 "00016"^^<xsd:double>;
+  aqm:valor_a_las_17 "00014"^^<xsd:double>;
+  aqm:valor_a_las_18 "00015"^^<xsd:double>;
+  aqm:valor_a_las_19 "00021"^^<xsd:double>;
+  aqm:valor_a_las_2 "00006"^^<xsd:double>;
+  aqm:valor_a_las_20 "00039"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00005"^^<xsd:double>;
+  aqm:valor_a_las_4 "00005"^^<xsd:double>;
+  aqm:valor_a_las_5 "00004"^^<xsd:double>;
+  aqm:valor_a_las_6 "00004"^^<xsd:double>;
+  aqm:valor_a_las_7 "00010"^^<xsd:double>;
+  aqm:valor_a_las_8 "00015"^^<xsd:double>;
+  aqm:valor_a_las_9 "00027"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079018_10_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 10 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079018";
+  aqm:id_medicion "28079018_10_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00007"^^<xsd:double>;
+  aqm:valor_a_las_10 "00011"^^<xsd:double>;
+  aqm:valor_a_las_11 "00011"^^<xsd:double>;
+  aqm:valor_a_las_12 "00013"^^<xsd:double>;
+  aqm:valor_a_las_13 "00010"^^<xsd:double>;
+  aqm:valor_a_las_14 "00007"^^<xsd:double>;
+  aqm:valor_a_las_15 "00005"^^<xsd:double>;
+  aqm:valor_a_las_16 "00014"^^<xsd:double>;
+  aqm:valor_a_las_17 "00020"^^<xsd:double>;
+  aqm:valor_a_las_18 "00013"^^<xsd:double>;
+  aqm:valor_a_las_19 "00001"^^<xsd:double>;
+  aqm:valor_a_las_2 "00007"^^<xsd:double>;
+  aqm:valor_a_las_20 "00008"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00008"^^<xsd:double>;
+  aqm:valor_a_las_4 "00009"^^<xsd:double>;
+  aqm:valor_a_las_5 "00009"^^<xsd:double>;
+  aqm:valor_a_las_6 "00006"^^<xsd:double>;
+  aqm:valor_a_las_7 "00008"^^<xsd:double>;
+  aqm:valor_a_las_8 "00009"^^<xsd:double>;
+  aqm:valor_a_las_9 "00011"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+10+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Microbalanza> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079018_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079018";
+  aqm:id_medicion "28079018_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00012"^^<xsd:double>;
+  aqm:valor_a_las_10 "00037"^^<xsd:double>;
+  aqm:valor_a_las_11 "00038"^^<xsd:double>;
+  aqm:valor_a_las_12 "00041"^^<xsd:double>;
+  aqm:valor_a_las_13 "00050"^^<xsd:double>;
+  aqm:valor_a_las_14 "00028"^^<xsd:double>;
+  aqm:valor_a_las_15 "00026"^^<xsd:double>;
+  aqm:valor_a_las_16 "00021"^^<xsd:double>;
+  aqm:valor_a_las_17 "00018"^^<xsd:double>;
+  aqm:valor_a_las_18 "00019"^^<xsd:double>;
+  aqm:valor_a_las_19 "00025"^^<xsd:double>;
+  aqm:valor_a_las_2 "00008"^^<xsd:double>;
+  aqm:valor_a_las_20 "00044"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00006"^^<xsd:double>;
+  aqm:valor_a_las_4 "00006"^^<xsd:double>;
+  aqm:valor_a_las_5 "00007"^^<xsd:double>;
+  aqm:valor_a_las_6 "00005"^^<xsd:double>;
+  aqm:valor_a_las_7 "00012"^^<xsd:double>;
+  aqm:valor_a_las_8 "00018"^^<xsd:double>;
+  aqm:valor_a_las_9 "00034"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079018_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079018";
+  aqm:id_medicion "28079018_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "66.45"^^<xsd:double>;
+  aqm:valor_a_las_10 "39.09"^^<xsd:double>;
+  aqm:valor_a_las_11 "44.45"^^<xsd:double>;
+  aqm:valor_a_las_12 "50.42"^^<xsd:double>;
+  aqm:valor_a_las_13 "52.53"^^<xsd:double>;
+  aqm:valor_a_las_14 "63.93"^^<xsd:double>;
+  aqm:valor_a_las_15 "68.89"^^<xsd:double>;
+  aqm:valor_a_las_16 "78.17"^^<xsd:double>;
+  aqm:valor_a_las_17 "83.52"^^<xsd:double>;
+  aqm:valor_a_las_18 "82.20"^^<xsd:double>;
+  aqm:valor_a_las_19 "73.78"^^<xsd:double>;
+  aqm:valor_a_las_2 "72.58"^^<xsd:double>;
+  aqm:valor_a_las_20 "53.63"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "71.81"^^<xsd:double>;
+  aqm:valor_a_las_4 "69.43"^^<xsd:double>;
+  aqm:valor_a_las_5 "67.98"^^<xsd:double>;
+  aqm:valor_a_las_6 "67.22"^^<xsd:double>;
+  aqm:valor_a_las_7 "60.52"^^<xsd:double>;
+  aqm:valor_a_las_8 "52.97"^^<xsd:double>;
+  aqm:valor_a_las_9 "41.69"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079018_20_59> a aqm:Measurement;
+  aqm:contaminante "Tolueno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079018";
+  aqm:id_medicion "28079018_20_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "001.0"^^<xsd:double>;
+  aqm:valor_a_las_10 "001.4"^^<xsd:double>;
+  aqm:valor_a_las_11 "001.9"^^<xsd:double>;
+  aqm:valor_a_las_12 "001.6"^^<xsd:double>;
+  aqm:valor_a_las_13 "002.7"^^<xsd:double>;
+  aqm:valor_a_las_14 "001.3"^^<xsd:double>;
+  aqm:valor_a_las_15 "001.4"^^<xsd:double>;
+  aqm:valor_a_las_16 "001.1"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.9"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_20 "001.1"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.7"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.5"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.6"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.7"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Tolueno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q15779" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FCromatograf%C3%ADa+de+gases> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079018_30_59> a aqm:Measurement;
+  aqm:contaminante "Benceno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079018";
+  aqm:id_medicion "28079018_30_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.5"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.1"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Benceno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2270" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079018_35_59> a aqm:Measurement;
+  aqm:contaminante "Etilbenceno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079018";
+  aqm:id_medicion "28079018_35_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.1"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Etilbenceno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q409184" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FCromatograf%C3%ADa+de+gases> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_1_38> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Azufre";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_1_38";
+  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00004"^^<xsd:double>;
+  aqm:valor_a_las_10 "00004"^^<xsd:double>;
+  aqm:valor_a_las_11 "00005"^^<xsd:double>;
+  aqm:valor_a_las_12 "00005"^^<xsd:double>;
+  aqm:valor_a_las_13 "00005"^^<xsd:double>;
+  aqm:valor_a_las_14 "00005"^^<xsd:double>;
+  aqm:valor_a_las_15 "00005"^^<xsd:double>;
+  aqm:valor_a_las_16 "00005"^^<xsd:double>;
+  aqm:valor_a_las_17 "00004"^^<xsd:double>;
+  aqm:valor_a_las_18 "00004"^^<xsd:double>;
+  aqm:valor_a_las_19 "00004"^^<xsd:double>;
+  aqm:valor_a_las_2 "00004"^^<xsd:double>;
+  aqm:valor_a_las_20 "00004"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00004"^^<xsd:double>;
+  aqm:valor_a_las_4 "00004"^^<xsd:double>;
+  aqm:valor_a_las_5 "00004"^^<xsd:double>;
+  aqm:valor_a_las_6 "00004"^^<xsd:double>;
+  aqm:valor_a_las_7 "00004"^^<xsd:double>;
+  aqm:valor_a_las_8 "00004"^^<xsd:double>;
+  aqm:valor_a_las_9 "00004"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Azufre> a
+    aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q5282" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FFluorescencia+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_6_48> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Carbono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_6_48";
+  aqm:tecnica "Absorción infrarroja";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.1"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Carbono>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2025" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+infrarroja> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00003"^^<xsd:double>;
+  aqm:valor_a_las_11 "00005"^^<xsd:double>;
+  aqm:valor_a_las_12 "00005"^^<xsd:double>;
+  aqm:valor_a_las_13 "00006"^^<xsd:double>;
+  aqm:valor_a_las_14 "00004"^^<xsd:double>;
+  aqm:valor_a_las_15 "00002"^^<xsd:double>;
+  aqm:valor_a_las_16 "00002"^^<xsd:double>;
+  aqm:valor_a_las_17 "00001"^^<xsd:double>;
+  aqm:valor_a_las_18 "00001"^^<xsd:double>;
+  aqm:valor_a_las_19 "00001"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00001"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00001"^^<xsd:double>;
+  aqm:valor_a_las_8 "00001"^^<xsd:double>;
+  aqm:valor_a_las_9 "00001"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00003"^^<xsd:double>;
+  aqm:valor_a_las_10 "00019"^^<xsd:double>;
+  aqm:valor_a_las_11 "00019"^^<xsd:double>;
+  aqm:valor_a_las_12 "00017"^^<xsd:double>;
+  aqm:valor_a_las_13 "00021"^^<xsd:double>;
+  aqm:valor_a_las_14 "00015"^^<xsd:double>;
+  aqm:valor_a_las_15 "00011"^^<xsd:double>;
+  aqm:valor_a_las_16 "00009"^^<xsd:double>;
+  aqm:valor_a_las_17 "00005"^^<xsd:double>;
+  aqm:valor_a_las_18 "00006"^^<xsd:double>;
+  aqm:valor_a_las_19 "00010"^^<xsd:double>;
+  aqm:valor_a_las_2 "00002"^^<xsd:double>;
+  aqm:valor_a_las_20 "00021"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00002"^^<xsd:double>;
+  aqm:valor_a_las_4 "00002"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00002"^^<xsd:double>;
+  aqm:valor_a_las_7 "00003"^^<xsd:double>;
+  aqm:valor_a_las_8 "00006"^^<xsd:double>;
+  aqm:valor_a_las_9 "00013"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_9_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_9_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00000"^^<xsd:double>;
+  aqm:valor_a_las_10 "00000"^^<xsd:double>;
+  aqm:valor_a_las_11 "00000"^^<xsd:double>;
+  aqm:valor_a_las_12 "00000"^^<xsd:double>;
+  aqm:valor_a_las_13 "00001"^^<xsd:double>;
+  aqm:valor_a_las_14 "00004"^^<xsd:double>;
+  aqm:valor_a_las_15 "00007"^^<xsd:double>;
+  aqm:valor_a_las_16 "00003"^^<xsd:double>;
+  aqm:valor_a_las_17 "00001"^^<xsd:double>;
+  aqm:valor_a_las_18 "00002"^^<xsd:double>;
+  aqm:valor_a_las_19 "00003"^^<xsd:double>;
+  aqm:valor_a_las_2 "00000"^^<xsd:double>;
+  aqm:valor_a_las_20 "00001"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00000"^^<xsd:double>;
+  aqm:valor_a_las_4 "00000"^^<xsd:double>;
+  aqm:valor_a_las_5 "00000"^^<xsd:double>;
+  aqm:valor_a_las_6 "00000"^^<xsd:double>;
+  aqm:valor_a_las_7 "00000"^^<xsd:double>;
+  aqm:valor_a_las_8 "00000"^^<xsd:double>;
+  aqm:valor_a_las_9 "00000"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+2.5+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Microbalanza> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_10_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 10 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_10_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00000"^^<xsd:double>;
+  aqm:valor_a_las_10 "00000"^^<xsd:double>;
+  aqm:valor_a_las_11 "00000"^^<xsd:double>;
+  aqm:valor_a_las_12 "00000"^^<xsd:double>;
+  aqm:valor_a_las_13 "00001"^^<xsd:double>;
+  aqm:valor_a_las_14 "00007"^^<xsd:double>;
+  aqm:valor_a_las_15 "00014"^^<xsd:double>;
+  aqm:valor_a_las_16 "00010"^^<xsd:double>;
+  aqm:valor_a_las_17 "00006"^^<xsd:double>;
+  aqm:valor_a_las_18 "00006"^^<xsd:double>;
+  aqm:valor_a_las_19 "00008"^^<xsd:double>;
+  aqm:valor_a_las_2 "00000"^^<xsd:double>;
+  aqm:valor_a_las_20 "00006"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00000"^^<xsd:double>;
+  aqm:valor_a_las_4 "00000"^^<xsd:double>;
+  aqm:valor_a_las_5 "00000"^^<xsd:double>;
+  aqm:valor_a_las_6 "00000"^^<xsd:double>;
+  aqm:valor_a_las_7 "00000"^^<xsd:double>;
+  aqm:valor_a_las_8 "00000"^^<xsd:double>;
+  aqm:valor_a_las_9 "00000"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+10+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00004"^^<xsd:double>;
+  aqm:valor_a_las_10 "00023"^^<xsd:double>;
+  aqm:valor_a_las_11 "00026"^^<xsd:double>;
+  aqm:valor_a_las_12 "00024"^^<xsd:double>;
+  aqm:valor_a_las_13 "00030"^^<xsd:double>;
+  aqm:valor_a_las_14 "00021"^^<xsd:double>;
+  aqm:valor_a_las_15 "00015"^^<xsd:double>;
+  aqm:valor_a_las_16 "00012"^^<xsd:double>;
+  aqm:valor_a_las_17 "00006"^^<xsd:double>;
+  aqm:valor_a_las_18 "00007"^^<xsd:double>;
+  aqm:valor_a_las_19 "00012"^^<xsd:double>;
+  aqm:valor_a_las_2 "00004"^^<xsd:double>;
+  aqm:valor_a_las_20 "00022"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00003"^^<xsd:double>;
+  aqm:valor_a_las_4 "00004"^^<xsd:double>;
+  aqm:valor_a_las_5 "00003"^^<xsd:double>;
+  aqm:valor_a_las_6 "00003"^^<xsd:double>;
+  aqm:valor_a_las_7 "00005"^^<xsd:double>;
+  aqm:valor_a_las_8 "00008"^^<xsd:double>;
+  aqm:valor_a_las_9 "00015"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "80.48"^^<xsd:double>;
+  aqm:valor_a_las_10 "52.17"^^<xsd:double>;
+  aqm:valor_a_las_11 "54.75"^^<xsd:double>;
+  aqm:valor_a_las_12 "62.07"^^<xsd:double>;
+  aqm:valor_a_las_13 "62.05"^^<xsd:double>;
+  aqm:valor_a_las_14 "71.01"^^<xsd:double>;
+  aqm:valor_a_las_15 "79.71"^^<xsd:double>;
+  aqm:valor_a_las_16 "87.49"^^<xsd:double>;
+  aqm:valor_a_las_17 "94.47"^^<xsd:double>;
+  aqm:valor_a_las_18 "93.66"^^<xsd:double>;
+  aqm:valor_a_las_19 "84.93"^^<xsd:double>;
+  aqm:valor_a_las_2 "81.94"^^<xsd:double>;
+  aqm:valor_a_las_20 "69.61"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "79.37"^^<xsd:double>;
+  aqm:valor_a_las_4 "76.05"^^<xsd:double>;
+  aqm:valor_a_las_5 "76.09"^^<xsd:double>;
+  aqm:valor_a_las_6 "74.27"^^<xsd:double>;
+  aqm:valor_a_las_7 "69.50"^^<xsd:double>;
+  aqm:valor_a_las_8 "64.69"^^<xsd:double>;
+  aqm:valor_a_las_9 "56.94"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_20_59> a aqm:Measurement;
+  aqm:contaminante "Tolueno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_20_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.6"^^<xsd:double>;
+  aqm:valor_a_las_12 "001.0"^^<xsd:double>;
+  aqm:valor_a_las_13 "001.4"^^<xsd:double>;
+  aqm:valor_a_las_14 "00000"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.6"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.7"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.2"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Tolueno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q15779" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FCromatograf%C3%ADa+de+gases> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_30_59> a aqm:Measurement;
+  aqm:contaminante "Benceno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_30_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_14 "00000"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.1"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Benceno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2270" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_35_59> a aqm:Measurement;
+  aqm:contaminante "Etilbenceno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_35_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_14 "00000"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.1"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Etilbenceno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q409184" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FCromatograf%C3%ADa+de+gases> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_42_2> a aqm:Measurement;
+  aqm:contaminante "Hidrocarburos totales (hexano)";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_42_2";
+  aqm:tecnica "Ionización de llama";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "01.16"^^<xsd:double>;
+  aqm:valor_a_las_10 "01.17"^^<xsd:double>;
+  aqm:valor_a_las_11 "01.18"^^<xsd:double>;
+  aqm:valor_a_las_12 "01.20"^^<xsd:double>;
+  aqm:valor_a_las_13 "01.21"^^<xsd:double>;
+  aqm:valor_a_las_14 "01.21"^^<xsd:double>;
+  aqm:valor_a_las_15 "01.20"^^<xsd:double>;
+  aqm:valor_a_las_16 "01.20"^^<xsd:double>;
+  aqm:valor_a_las_17 "01.19"^^<xsd:double>;
+  aqm:valor_a_las_18 "01.18"^^<xsd:double>;
+  aqm:valor_a_las_19 "01.19"^^<xsd:double>;
+  aqm:valor_a_las_2 "01.16"^^<xsd:double>;
+  aqm:valor_a_las_20 "01.19"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "01.17"^^<xsd:double>;
+  aqm:valor_a_las_4 "01.16"^^<xsd:double>;
+  aqm:valor_a_las_5 "01.16"^^<xsd:double>;
+  aqm:valor_a_las_6 "01.16"^^<xsd:double>;
+  aqm:valor_a_las_7 "01.16"^^<xsd:double>;
+  aqm:valor_a_las_8 "01.16"^^<xsd:double>;
+  aqm:valor_a_las_9 "01.16"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FHidrocarburos+totales+%28hexano%29>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FIonizaci%C3%B3n+de+llama> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q873305" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_43_2> a aqm:Measurement;
+  aqm:contaminante "Metano";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_43_2";
+  aqm:tecnica "Ionización de llama";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "01.10"^^<xsd:double>;
+  aqm:valor_a_las_10 "01.09"^^<xsd:double>;
+  aqm:valor_a_las_11 "01.10"^^<xsd:double>;
+  aqm:valor_a_las_12 "01.12"^^<xsd:double>;
+  aqm:valor_a_las_13 "01.13"^^<xsd:double>;
+  aqm:valor_a_las_14 "01.14"^^<xsd:double>;
+  aqm:valor_a_las_15 "01.14"^^<xsd:double>;
+  aqm:valor_a_las_16 "01.14"^^<xsd:double>;
+  aqm:valor_a_las_17 "01.13"^^<xsd:double>;
+  aqm:valor_a_las_18 "01.12"^^<xsd:double>;
+  aqm:valor_a_las_19 "01.11"^^<xsd:double>;
+  aqm:valor_a_las_2 "01.10"^^<xsd:double>;
+  aqm:valor_a_las_20 "01.12"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "01.10"^^<xsd:double>;
+  aqm:valor_a_las_4 "01.09"^^<xsd:double>;
+  aqm:valor_a_las_5 "01.09"^^<xsd:double>;
+  aqm:valor_a_las_6 "01.09"^^<xsd:double>;
+  aqm:valor_a_las_7 "01.09"^^<xsd:double>;
+  aqm:valor_a_las_8 "01.10"^^<xsd:double>;
+  aqm:valor_a_las_9 "01.09"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Metano> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q37129" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079024_44_2> a aqm:Measurement;
+  aqm:contaminante "Hidrocarburos no metánicos (hexano)";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079024";
+  aqm:id_medicion "28079024_44_2";
+  aqm:tecnica "Ionización de llama";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "00.06"^^<xsd:double>;
+  aqm:valor_a_las_10 "00.08"^^<xsd:double>;
+  aqm:valor_a_las_11 "00.08"^^<xsd:double>;
+  aqm:valor_a_las_12 "00.08"^^<xsd:double>;
+  aqm:valor_a_las_13 "00.08"^^<xsd:double>;
+  aqm:valor_a_las_14 "00.07"^^<xsd:double>;
+  aqm:valor_a_las_15 "00.06"^^<xsd:double>;
+  aqm:valor_a_las_16 "00.06"^^<xsd:double>;
+  aqm:valor_a_las_17 "00.06"^^<xsd:double>;
+  aqm:valor_a_las_18 "00.06"^^<xsd:double>;
+  aqm:valor_a_las_19 "00.08"^^<xsd:double>;
+  aqm:valor_a_las_2 "00.06"^^<xsd:double>;
+  aqm:valor_a_las_20 "00.08"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00.07"^^<xsd:double>;
+  aqm:valor_a_las_4 "00.07"^^<xsd:double>;
+  aqm:valor_a_las_5 "00.07"^^<xsd:double>;
+  aqm:valor_a_las_6 "00.07"^^<xsd:double>;
+  aqm:valor_a_las_7 "00.07"^^<xsd:double>;
+  aqm:valor_a_las_8 "00.06"^^<xsd:double>;
+  aqm:valor_a_las_9 "00.07"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FHidrocarburos+no+met%C3%A1nicos+%28hexano%29>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FIonizaci%C3%B3n+de+llama> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q873305" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079027_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079027";
+  aqm:id_medicion "28079027_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00033"^^<xsd:double>;
+  aqm:valor_a_las_11 "00017"^^<xsd:double>;
+  aqm:valor_a_las_12 "00005"^^<xsd:double>;
+  aqm:valor_a_las_13 "00006"^^<xsd:double>;
+  aqm:valor_a_las_14 "00004"^^<xsd:double>;
+  aqm:valor_a_las_15 "00003"^^<xsd:double>;
+  aqm:valor_a_las_16 "00004"^^<xsd:double>;
+  aqm:valor_a_las_17 "00004"^^<xsd:double>;
+  aqm:valor_a_las_18 "00004"^^<xsd:double>;
+  aqm:valor_a_las_19 "00004"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00004"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00007"^^<xsd:double>;
+  aqm:valor_a_las_8 "00008"^^<xsd:double>;
+  aqm:valor_a_las_9 "00026"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079027_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079027";
+  aqm:id_medicion "28079027_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00052"^^<xsd:double>;
+  aqm:valor_a_las_10 "00073"^^<xsd:double>;
+  aqm:valor_a_las_11 "00046"^^<xsd:double>;
+  aqm:valor_a_las_12 "00019"^^<xsd:double>;
+  aqm:valor_a_las_13 "00020"^^<xsd:double>;
+  aqm:valor_a_las_14 "00016"^^<xsd:double>;
+  aqm:valor_a_las_15 "00013"^^<xsd:double>;
+  aqm:valor_a_las_16 "00017"^^<xsd:double>;
+  aqm:valor_a_las_17 "00016"^^<xsd:double>;
+  aqm:valor_a_las_18 "00023"^^<xsd:double>;
+  aqm:valor_a_las_19 "00026"^^<xsd:double>;
+  aqm:valor_a_las_2 "00028"^^<xsd:double>;
+  aqm:valor_a_las_20 "00034"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00006"^^<xsd:double>;
+  aqm:valor_a_las_4 "00005"^^<xsd:double>;
+  aqm:valor_a_las_5 "00004"^^<xsd:double>;
+  aqm:valor_a_las_6 "00007"^^<xsd:double>;
+  aqm:valor_a_las_7 "00044"^^<xsd:double>;
+  aqm:valor_a_las_8 "00058"^^<xsd:double>;
+  aqm:valor_a_las_9 "00086"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079027_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079027";
+  aqm:id_medicion "28079027_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00054"^^<xsd:double>;
+  aqm:valor_a_las_10 "00123"^^<xsd:double>;
+  aqm:valor_a_las_11 "00072"^^<xsd:double>;
+  aqm:valor_a_las_12 "00027"^^<xsd:double>;
+  aqm:valor_a_las_13 "00028"^^<xsd:double>;
+  aqm:valor_a_las_14 "00022"^^<xsd:double>;
+  aqm:valor_a_las_15 "00017"^^<xsd:double>;
+  aqm:valor_a_las_16 "00023"^^<xsd:double>;
+  aqm:valor_a_las_17 "00022"^^<xsd:double>;
+  aqm:valor_a_las_18 "00030"^^<xsd:double>;
+  aqm:valor_a_las_19 "00032"^^<xsd:double>;
+  aqm:valor_a_las_2 "00030"^^<xsd:double>;
+  aqm:valor_a_las_20 "00041"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00007"^^<xsd:double>;
+  aqm:valor_a_las_4 "00006"^^<xsd:double>;
+  aqm:valor_a_las_5 "00006"^^<xsd:double>;
+  aqm:valor_a_las_6 "00008"^^<xsd:double>;
+  aqm:valor_a_las_7 "00055"^^<xsd:double>;
+  aqm:valor_a_las_8 "00071"^^<xsd:double>;
+  aqm:valor_a_las_9 "00127"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079027_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079027";
+  aqm:id_medicion "28079027_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "35.55"^^<xsd:double>;
+  aqm:valor_a_las_10 "16.90"^^<xsd:double>;
+  aqm:valor_a_las_11 "38.60"^^<xsd:double>;
+  aqm:valor_a_las_12 "58.22"^^<xsd:double>;
+  aqm:valor_a_las_13 "62.21"^^<xsd:double>;
+  aqm:valor_a_las_14 "70.91"^^<xsd:double>;
+  aqm:valor_a_las_15 "79.11"^^<xsd:double>;
+  aqm:valor_a_las_16 "76.29"^^<xsd:double>;
+  aqm:valor_a_las_17 "77.82"^^<xsd:double>;
+  aqm:valor_a_las_18 "71.92"^^<xsd:double>;
+  aqm:valor_a_las_19 "68.05"^^<xsd:double>;
+  aqm:valor_a_las_2 "56.51"^^<xsd:double>;
+  aqm:valor_a_las_20 "57.15"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "71.48"^^<xsd:double>;
+  aqm:valor_a_las_4 "69.15"^^<xsd:double>;
+  aqm:valor_a_las_5 "67.21"^^<xsd:double>;
+  aqm:valor_a_las_6 "64.45"^^<xsd:double>;
+  aqm:valor_a_las_7 "39.57"^^<xsd:double>;
+  aqm:valor_a_las_8 "23.91"^^<xsd:double>;
+  aqm:valor_a_las_9 "05.53"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079035_1_38> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Azufre";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079035";
+  aqm:id_medicion "28079035_1_38";
+  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00009"^^<xsd:double>;
+  aqm:valor_a_las_10 "00012"^^<xsd:double>;
+  aqm:valor_a_las_11 "00017"^^<xsd:double>;
+  aqm:valor_a_las_12 "00020"^^<xsd:double>;
+  aqm:valor_a_las_13 "00017"^^<xsd:double>;
+  aqm:valor_a_las_14 "00017"^^<xsd:double>;
+  aqm:valor_a_las_15 "00017"^^<xsd:double>;
+  aqm:valor_a_las_16 "00017"^^<xsd:double>;
+  aqm:valor_a_las_17 "00017"^^<xsd:double>;
+  aqm:valor_a_las_18 "00017"^^<xsd:double>;
+  aqm:valor_a_las_19 "00017"^^<xsd:double>;
+  aqm:valor_a_las_2 "00009"^^<xsd:double>;
+  aqm:valor_a_las_20 "00018"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00009"^^<xsd:double>;
+  aqm:valor_a_las_4 "00009"^^<xsd:double>;
+  aqm:valor_a_las_5 "00009"^^<xsd:double>;
+  aqm:valor_a_las_6 "00009"^^<xsd:double>;
+  aqm:valor_a_las_7 "00010"^^<xsd:double>;
+  aqm:valor_a_las_8 "00008"^^<xsd:double>;
+  aqm:valor_a_las_9 "00009"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Azufre> a
+    aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q5282" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FFluorescencia+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079035_6_48> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Carbono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079035";
+  aqm:id_medicion "28079035_6_48";
+  aqm:tecnica "Absorción infrarroja";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.9"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.7"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.7"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.7"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.8"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.9"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Carbono>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2025" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+infrarroja> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079035_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079035";
+  aqm:id_medicion "28079035_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00015"^^<xsd:double>;
+  aqm:valor_a_las_11 "00015"^^<xsd:double>;
+  aqm:valor_a_las_12 "00027"^^<xsd:double>;
+  aqm:valor_a_las_13 "00020"^^<xsd:double>;
+  aqm:valor_a_las_14 "00015"^^<xsd:double>;
+  aqm:valor_a_las_15 "00010"^^<xsd:double>;
+  aqm:valor_a_las_16 "00007"^^<xsd:double>;
+  aqm:valor_a_las_17 "00008"^^<xsd:double>;
+  aqm:valor_a_las_18 "00010"^^<xsd:double>;
+  aqm:valor_a_las_19 "00009"^^<xsd:double>;
+  aqm:valor_a_las_2 "00002"^^<xsd:double>;
+  aqm:valor_a_las_20 "00008"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00004"^^<xsd:double>;
+  aqm:valor_a_las_8 "00005"^^<xsd:double>;
+  aqm:valor_a_las_9 "00011"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079035_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079035";
+  aqm:id_medicion "28079035_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00016"^^<xsd:double>;
+  aqm:valor_a_las_10 "00049"^^<xsd:double>;
+  aqm:valor_a_las_11 "00045"^^<xsd:double>;
+  aqm:valor_a_las_12 "00051"^^<xsd:double>;
+  aqm:valor_a_las_13 "00044"^^<xsd:double>;
+  aqm:valor_a_las_14 "00037"^^<xsd:double>;
+  aqm:valor_a_las_15 "00031"^^<xsd:double>;
+  aqm:valor_a_las_16 "00027"^^<xsd:double>;
+  aqm:valor_a_las_17 "00029"^^<xsd:double>;
+  aqm:valor_a_las_18 "00038"^^<xsd:double>;
+  aqm:valor_a_las_19 "00037"^^<xsd:double>;
+  aqm:valor_a_las_2 "00017"^^<xsd:double>;
+  aqm:valor_a_las_20 "00049"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00010"^^<xsd:double>;
+  aqm:valor_a_las_4 "00008"^^<xsd:double>;
+  aqm:valor_a_las_5 "00009"^^<xsd:double>;
+  aqm:valor_a_las_6 "00008"^^<xsd:double>;
+  aqm:valor_a_las_7 "00020"^^<xsd:double>;
+  aqm:valor_a_las_8 "00032"^^<xsd:double>;
+  aqm:valor_a_las_9 "00053"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079035_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079035";
+  aqm:id_medicion "28079035_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00019"^^<xsd:double>;
+  aqm:valor_a_las_10 "00072"^^<xsd:double>;
+  aqm:valor_a_las_11 "00068"^^<xsd:double>;
+  aqm:valor_a_las_12 "00091"^^<xsd:double>;
+  aqm:valor_a_las_13 "00075"^^<xsd:double>;
+  aqm:valor_a_las_14 "00061"^^<xsd:double>;
+  aqm:valor_a_las_15 "00047"^^<xsd:double>;
+  aqm:valor_a_las_16 "00039"^^<xsd:double>;
+  aqm:valor_a_las_17 "00042"^^<xsd:double>;
+  aqm:valor_a_las_18 "00052"^^<xsd:double>;
+  aqm:valor_a_las_19 "00051"^^<xsd:double>;
+  aqm:valor_a_las_2 "00020"^^<xsd:double>;
+  aqm:valor_a_las_20 "00061"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00012"^^<xsd:double>;
+  aqm:valor_a_las_4 "00010"^^<xsd:double>;
+  aqm:valor_a_las_5 "00011"^^<xsd:double>;
+  aqm:valor_a_las_6 "00009"^^<xsd:double>;
+  aqm:valor_a_las_7 "00027"^^<xsd:double>;
+  aqm:valor_a_las_8 "00039"^^<xsd:double>;
+  aqm:valor_a_las_9 "00069"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079035_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079035";
+  aqm:id_medicion "28079035_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "63.05"^^<xsd:double>;
+  aqm:valor_a_las_10 "26.21"^^<xsd:double>;
+  aqm:valor_a_las_11 "36.22"^^<xsd:double>;
+  aqm:valor_a_las_12 "33.50"^^<xsd:double>;
+  aqm:valor_a_las_13 "37.97"^^<xsd:double>;
+  aqm:valor_a_las_14 "47.03"^^<xsd:double>;
+  aqm:valor_a_las_15 "57.35"^^<xsd:double>;
+  aqm:valor_a_las_16 "65.89"^^<xsd:double>;
+  aqm:valor_a_las_17 "65.00"^^<xsd:double>;
+  aqm:valor_a_las_18 "54.38"^^<xsd:double>;
+  aqm:valor_a_las_19 "57.44"^^<xsd:double>;
+  aqm:valor_a_las_2 "65.49"^^<xsd:double>;
+  aqm:valor_a_las_20 "40.64"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "65.88"^^<xsd:double>;
+  aqm:valor_a_las_4 "64.18"^^<xsd:double>;
+  aqm:valor_a_las_5 "61.32"^^<xsd:double>;
+  aqm:valor_a_las_6 "63.08"^^<xsd:double>;
+  aqm:valor_a_las_7 "52.22"^^<xsd:double>;
+  aqm:valor_a_las_8 "39.60"^^<xsd:double>;
+  aqm:valor_a_las_9 "24.71"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079036_1_38> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Azufre";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079036";
+  aqm:id_medicion "28079036_1_38";
+  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00004"^^<xsd:double>;
+  aqm:valor_a_las_10 "00004"^^<xsd:double>;
+  aqm:valor_a_las_11 "00004"^^<xsd:double>;
+  aqm:valor_a_las_12 "00004"^^<xsd:double>;
+  aqm:valor_a_las_13 "00004"^^<xsd:double>;
+  aqm:valor_a_las_14 "00004"^^<xsd:double>;
+  aqm:valor_a_las_15 "00004"^^<xsd:double>;
+  aqm:valor_a_las_16 "00004"^^<xsd:double>;
+  aqm:valor_a_las_17 "00004"^^<xsd:double>;
+  aqm:valor_a_las_18 "00004"^^<xsd:double>;
+  aqm:valor_a_las_19 "00004"^^<xsd:double>;
+  aqm:valor_a_las_2 "00004"^^<xsd:double>;
+  aqm:valor_a_las_20 "00004"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00004"^^<xsd:double>;
+  aqm:valor_a_las_4 "00004"^^<xsd:double>;
+  aqm:valor_a_las_5 "00004"^^<xsd:double>;
+  aqm:valor_a_las_6 "00004"^^<xsd:double>;
+  aqm:valor_a_las_7 "00004"^^<xsd:double>;
+  aqm:valor_a_las_8 "00004"^^<xsd:double>;
+  aqm:valor_a_las_9 "00004"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Azufre> a
+    aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q5282" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FFluorescencia+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079036_6_48> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Carbono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079036";
+  aqm:id_medicion "28079036_6_48";
+  aqm:tecnica "Absorción infrarroja";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.4"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Carbono>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2025" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+infrarroja> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079036_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079036";
+  aqm:id_medicion "28079036_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00003"^^<xsd:double>;
+  aqm:valor_a_las_10 "00025"^^<xsd:double>;
+  aqm:valor_a_las_11 "00011"^^<xsd:double>;
+  aqm:valor_a_las_12 "00010"^^<xsd:double>;
+  aqm:valor_a_las_13 "00007"^^<xsd:double>;
+  aqm:valor_a_las_14 "00005"^^<xsd:double>;
+  aqm:valor_a_las_15 "00004"^^<xsd:double>;
+  aqm:valor_a_las_16 "00006"^^<xsd:double>;
+  aqm:valor_a_las_17 "00005"^^<xsd:double>;
+  aqm:valor_a_las_18 "00005"^^<xsd:double>;
+  aqm:valor_a_las_19 "00004"^^<xsd:double>;
+  aqm:valor_a_las_2 "00002"^^<xsd:double>;
+  aqm:valor_a_las_20 "00007"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00002"^^<xsd:double>;
+  aqm:valor_a_las_4 "00002"^^<xsd:double>;
+  aqm:valor_a_las_5 "00002"^^<xsd:double>;
+  aqm:valor_a_las_6 "00002"^^<xsd:double>;
+  aqm:valor_a_las_7 "00003"^^<xsd:double>;
+  aqm:valor_a_las_8 "00010"^^<xsd:double>;
+  aqm:valor_a_las_9 "00015"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079036_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079036";
+  aqm:id_medicion "28079036_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00009"^^<xsd:double>;
+  aqm:valor_a_las_10 "00056"^^<xsd:double>;
+  aqm:valor_a_las_11 "00028"^^<xsd:double>;
+  aqm:valor_a_las_12 "00028"^^<xsd:double>;
+  aqm:valor_a_las_13 "00015"^^<xsd:double>;
+  aqm:valor_a_las_14 "00012"^^<xsd:double>;
+  aqm:valor_a_las_15 "00009"^^<xsd:double>;
+  aqm:valor_a_las_16 "00014"^^<xsd:double>;
+  aqm:valor_a_las_17 "00012"^^<xsd:double>;
+  aqm:valor_a_las_18 "00013"^^<xsd:double>;
+  aqm:valor_a_las_19 "00013"^^<xsd:double>;
+  aqm:valor_a_las_2 "00004"^^<xsd:double>;
+  aqm:valor_a_las_20 "00027"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00003"^^<xsd:double>;
+  aqm:valor_a_las_4 "00003"^^<xsd:double>;
+  aqm:valor_a_las_5 "00002"^^<xsd:double>;
+  aqm:valor_a_las_6 "00004"^^<xsd:double>;
+  aqm:valor_a_las_7 "00011"^^<xsd:double>;
+  aqm:valor_a_las_8 "00031"^^<xsd:double>;
+  aqm:valor_a_las_9 "00051"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079036_10_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 10 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079036";
+  aqm:id_medicion "28079036_10_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00012"^^<xsd:double>;
+  aqm:valor_a_las_10 "00021"^^<xsd:double>;
+  aqm:valor_a_las_11 "00029"^^<xsd:double>;
+  aqm:valor_a_las_12 "00010"^^<xsd:double>;
+  aqm:valor_a_las_13 "00015"^^<xsd:double>;
+  aqm:valor_a_las_14 "00006"^^<xsd:double>;
+  aqm:valor_a_las_15 "00010"^^<xsd:double>;
+  aqm:valor_a_las_16 "00017"^^<xsd:double>;
+  aqm:valor_a_las_17 "00009"^^<xsd:double>;
+  aqm:valor_a_las_18 "00003"^^<xsd:double>;
+  aqm:valor_a_las_19 "00002"^^<xsd:double>;
+  aqm:valor_a_las_2 "00013"^^<xsd:double>;
+  aqm:valor_a_las_20 "00020"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00014"^^<xsd:double>;
+  aqm:valor_a_las_4 "00015"^^<xsd:double>;
+  aqm:valor_a_las_5 "00014"^^<xsd:double>;
+  aqm:valor_a_las_6 "00011"^^<xsd:double>;
+  aqm:valor_a_las_7 "00010"^^<xsd:double>;
+  aqm:valor_a_las_8 "00013"^^<xsd:double>;
+  aqm:valor_a_las_9 "00015"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+10+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Microbalanza> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079036_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079036";
+  aqm:id_medicion "28079036_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00013"^^<xsd:double>;
+  aqm:valor_a_las_10 "00094"^^<xsd:double>;
+  aqm:valor_a_las_11 "00045"^^<xsd:double>;
+  aqm:valor_a_las_12 "00043"^^<xsd:double>;
+  aqm:valor_a_las_13 "00027"^^<xsd:double>;
+  aqm:valor_a_las_14 "00020"^^<xsd:double>;
+  aqm:valor_a_las_15 "00015"^^<xsd:double>;
+  aqm:valor_a_las_16 "00023"^^<xsd:double>;
+  aqm:valor_a_las_17 "00019"^^<xsd:double>;
+  aqm:valor_a_las_18 "00020"^^<xsd:double>;
+  aqm:valor_a_las_19 "00020"^^<xsd:double>;
+  aqm:valor_a_las_2 "00007"^^<xsd:double>;
+  aqm:valor_a_las_20 "00038"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00006"^^<xsd:double>;
+  aqm:valor_a_las_4 "00006"^^<xsd:double>;
+  aqm:valor_a_las_5 "00005"^^<xsd:double>;
+  aqm:valor_a_las_6 "00007"^^<xsd:double>;
+  aqm:valor_a_las_7 "00016"^^<xsd:double>;
+  aqm:valor_a_las_8 "00047"^^<xsd:double>;
+  aqm:valor_a_las_9 "00074"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079038_1_38> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Azufre";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079038";
+  aqm:id_medicion "28079038_1_38";
+  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00007"^^<xsd:double>;
+  aqm:valor_a_las_10 "00009"^^<xsd:double>;
+  aqm:valor_a_las_11 "00007"^^<xsd:double>;
+  aqm:valor_a_las_12 "00007"^^<xsd:double>;
+  aqm:valor_a_las_13 "00007"^^<xsd:double>;
+  aqm:valor_a_las_14 "00007"^^<xsd:double>;
+  aqm:valor_a_las_15 "00007"^^<xsd:double>;
+  aqm:valor_a_las_16 "00006"^^<xsd:double>;
+  aqm:valor_a_las_17 "00006"^^<xsd:double>;
+  aqm:valor_a_las_18 "00006"^^<xsd:double>;
+  aqm:valor_a_las_19 "00006"^^<xsd:double>;
+  aqm:valor_a_las_2 "00007"^^<xsd:double>;
+  aqm:valor_a_las_20 "00007"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00007"^^<xsd:double>;
+  aqm:valor_a_las_4 "00007"^^<xsd:double>;
+  aqm:valor_a_las_5 "00007"^^<xsd:double>;
+  aqm:valor_a_las_6 "00007"^^<xsd:double>;
+  aqm:valor_a_las_7 "00007"^^<xsd:double>;
+  aqm:valor_a_las_8 "00008"^^<xsd:double>;
+  aqm:valor_a_las_9 "00009"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Azufre> a
+    aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q5282" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FFluorescencia+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079038_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079038";
+  aqm:id_medicion "28079038_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00003"^^<xsd:double>;
+  aqm:valor_a_las_10 "00039"^^<xsd:double>;
+  aqm:valor_a_las_11 "00025"^^<xsd:double>;
+  aqm:valor_a_las_12 "00020"^^<xsd:double>;
+  aqm:valor_a_las_13 "00018"^^<xsd:double>;
+  aqm:valor_a_las_14 "00014"^^<xsd:double>;
+  aqm:valor_a_las_15 "00016"^^<xsd:double>;
+  aqm:valor_a_las_16 "00012"^^<xsd:double>;
+  aqm:valor_a_las_17 "00017"^^<xsd:double>;
+  aqm:valor_a_las_18 "00014"^^<xsd:double>;
+  aqm:valor_a_las_19 "00012"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00023"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00003"^^<xsd:double>;
+  aqm:valor_a_las_8 "00009"^^<xsd:double>;
+  aqm:valor_a_las_9 "00029"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079038_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079038";
+  aqm:id_medicion "28079038_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00011"^^<xsd:double>;
+  aqm:valor_a_las_10 "00061"^^<xsd:double>;
+  aqm:valor_a_las_11 "00042"^^<xsd:double>;
+  aqm:valor_a_las_12 "00035"^^<xsd:double>;
+  aqm:valor_a_las_13 "00032"^^<xsd:double>;
+  aqm:valor_a_las_14 "00032"^^<xsd:double>;
+  aqm:valor_a_las_15 "00029"^^<xsd:double>;
+  aqm:valor_a_las_16 "00027"^^<xsd:double>;
+  aqm:valor_a_las_17 "00034"^^<xsd:double>;
+  aqm:valor_a_las_18 "00033"^^<xsd:double>;
+  aqm:valor_a_las_19 "00032"^^<xsd:double>;
+  aqm:valor_a_las_2 "00004"^^<xsd:double>;
+  aqm:valor_a_las_20 "00066"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00005"^^<xsd:double>;
+  aqm:valor_a_las_4 "00004"^^<xsd:double>;
+  aqm:valor_a_las_5 "00004"^^<xsd:double>;
+  aqm:valor_a_las_6 "00005"^^<xsd:double>;
+  aqm:valor_a_las_7 "00015"^^<xsd:double>;
+  aqm:valor_a_las_8 "00032"^^<xsd:double>;
+  aqm:valor_a_las_9 "00059"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079038_9_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079038";
+  aqm:id_medicion "28079038_9_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00002"^^<xsd:double>;
+  aqm:valor_a_las_10 "00009"^^<xsd:double>;
+  aqm:valor_a_las_11 "00007"^^<xsd:double>;
+  aqm:valor_a_las_12 "00001"^^<xsd:double>;
+  aqm:valor_a_las_13 "00002"^^<xsd:double>;
+  aqm:valor_a_las_14 "00006"^^<xsd:double>;
+  aqm:valor_a_las_15 "00013"^^<xsd:double>;
+  aqm:valor_a_las_16 "00011"^^<xsd:double>;
+  aqm:valor_a_las_17 "00005"^^<xsd:double>;
+  aqm:valor_a_las_18 "00004"^^<xsd:double>;
+  aqm:valor_a_las_19 "00004"^^<xsd:double>;
+  aqm:valor_a_las_2 "00002"^^<xsd:double>;
+  aqm:valor_a_las_20 "00005"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00002"^^<xsd:double>;
+  aqm:valor_a_las_4 "00003"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00002"^^<xsd:double>;
+  aqm:valor_a_las_7 "00003"^^<xsd:double>;
+  aqm:valor_a_las_8 "00001"^^<xsd:double>;
+  aqm:valor_a_las_9 "00002"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+2.5+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Microbalanza> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079038_10_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 10 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079038";
+  aqm:id_medicion "28079038_10_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00008"^^<xsd:double>;
+  aqm:valor_a_las_10 "00018"^^<xsd:double>;
+  aqm:valor_a_las_11 "00017"^^<xsd:double>;
+  aqm:valor_a_las_12 "00011"^^<xsd:double>;
+  aqm:valor_a_las_13 "00010"^^<xsd:double>;
+  aqm:valor_a_las_14 "00016"^^<xsd:double>;
+  aqm:valor_a_las_15 "00023"^^<xsd:double>;
+  aqm:valor_a_las_16 "00018"^^<xsd:double>;
+  aqm:valor_a_las_17 "00011"^^<xsd:double>;
+  aqm:valor_a_las_18 "00009"^^<xsd:double>;
+  aqm:valor_a_las_19 "00012"^^<xsd:double>;
+  aqm:valor_a_las_2 "00009"^^<xsd:double>;
+  aqm:valor_a_las_20 "00016"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00009"^^<xsd:double>;
+  aqm:valor_a_las_4 "00008"^^<xsd:double>;
+  aqm:valor_a_las_5 "00006"^^<xsd:double>;
+  aqm:valor_a_las_6 "00007"^^<xsd:double>;
+  aqm:valor_a_las_7 "00008"^^<xsd:double>;
+  aqm:valor_a_las_8 "00004"^^<xsd:double>;
+  aqm:valor_a_las_9 "00008"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+10+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079038_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079038";
+  aqm:id_medicion "28079038_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00015"^^<xsd:double>;
+  aqm:valor_a_las_10 "00121"^^<xsd:double>;
+  aqm:valor_a_las_11 "00080"^^<xsd:double>;
+  aqm:valor_a_las_12 "00066"^^<xsd:double>;
+  aqm:valor_a_las_13 "00059"^^<xsd:double>;
+  aqm:valor_a_las_14 "00054"^^<xsd:double>;
+  aqm:valor_a_las_15 "00053"^^<xsd:double>;
+  aqm:valor_a_las_16 "00046"^^<xsd:double>;
+  aqm:valor_a_las_17 "00060"^^<xsd:double>;
+  aqm:valor_a_las_18 "00054"^^<xsd:double>;
+  aqm:valor_a_las_19 "00050"^^<xsd:double>;
+  aqm:valor_a_las_2 "00005"^^<xsd:double>;
+  aqm:valor_a_las_20 "00101"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00006"^^<xsd:double>;
+  aqm:valor_a_las_4 "00005"^^<xsd:double>;
+  aqm:valor_a_las_5 "00005"^^<xsd:double>;
+  aqm:valor_a_las_6 "00006"^^<xsd:double>;
+  aqm:valor_a_las_7 "00019"^^<xsd:double>;
+  aqm:valor_a_las_8 "00045"^^<xsd:double>;
+  aqm:valor_a_las_9 "00104"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079038_20_59> a aqm:Measurement;
+  aqm:contaminante "Tolueno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079038";
+  aqm:id_medicion "28079038_20_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "000.7"^^<xsd:double>;
+  aqm:valor_a_las_10 "001.4"^^<xsd:double>;
+  aqm:valor_a_las_11 "001.7"^^<xsd:double>;
+  aqm:valor_a_las_12 "001.6"^^<xsd:double>;
+  aqm:valor_a_las_13 "001.8"^^<xsd:double>;
+  aqm:valor_a_las_14 "001.7"^^<xsd:double>;
+  aqm:valor_a_las_15 "001.8"^^<xsd:double>;
+  aqm:valor_a_las_16 "001.7"^^<xsd:double>;
+  aqm:valor_a_las_17 "001.3"^^<xsd:double>;
+  aqm:valor_a_las_18 "001.4"^^<xsd:double>;
+  aqm:valor_a_las_19 "001.3"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.5"^^<xsd:double>;
+  aqm:valor_a_las_20 "001.6"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.6"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Tolueno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q15779" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FCromatograf%C3%ADa+de+gases> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079038_30_59> a aqm:Measurement;
+  aqm:contaminante "Benceno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079038";
+  aqm:id_medicion "28079038_30_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.5"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.2"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Benceno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2270" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079038_35_59> a aqm:Measurement;
+  aqm:contaminante "Etilbenceno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079038";
+  aqm:id_medicion "28079038_35_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "004.0"^^<xsd:double>;
+  aqm:valor_a_las_10 "004.0"^^<xsd:double>;
+  aqm:valor_a_las_11 "004.6"^^<xsd:double>;
+  aqm:valor_a_las_12 "006.5"^^<xsd:double>;
+  aqm:valor_a_las_13 "005.3"^^<xsd:double>;
+  aqm:valor_a_las_14 "004.4"^^<xsd:double>;
+  aqm:valor_a_las_15 "004.1"^^<xsd:double>;
+  aqm:valor_a_las_16 "004.1"^^<xsd:double>;
+  aqm:valor_a_las_17 "004.0"^^<xsd:double>;
+  aqm:valor_a_las_18 "004.1"^^<xsd:double>;
+  aqm:valor_a_las_19 "004.3"^^<xsd:double>;
+  aqm:valor_a_las_2 "003.9"^^<xsd:double>;
+  aqm:valor_a_las_20 "004.4"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "003.4"^^<xsd:double>;
+  aqm:valor_a_las_4 "003.5"^^<xsd:double>;
+  aqm:valor_a_las_5 "003.5"^^<xsd:double>;
+  aqm:valor_a_las_6 "003.2"^^<xsd:double>;
+  aqm:valor_a_las_7 "003.3"^^<xsd:double>;
+  aqm:valor_a_las_8 "003.4"^^<xsd:double>;
+  aqm:valor_a_las_9 "003.8"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Etilbenceno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q409184" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FCromatograf%C3%ADa+de+gases> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079039_6_48> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Carbono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079039";
+  aqm:id_medicion "28079039_6_48";
+  aqm:tecnica "Absorción infrarroja";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_8 "001.2"^^<xsd:double>;
+  aqm:valor_a_las_9 "001.1"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Carbono>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2025" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+infrarroja> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079039_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079039";
+  aqm:id_medicion "28079039_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00010"^^<xsd:double>;
+  aqm:valor_a_las_11 "00005"^^<xsd:double>;
+  aqm:valor_a_las_12 "00005"^^<xsd:double>;
+  aqm:valor_a_las_13 "00006"^^<xsd:double>;
+  aqm:valor_a_las_14 "00005"^^<xsd:double>;
+  aqm:valor_a_las_15 "00004"^^<xsd:double>;
+  aqm:valor_a_las_16 "00005"^^<xsd:double>;
+  aqm:valor_a_las_17 "00002"^^<xsd:double>;
+  aqm:valor_a_las_18 "00002"^^<xsd:double>;
+  aqm:valor_a_las_19 "00002"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00001"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00002"^^<xsd:double>;
+  aqm:valor_a_las_8 "00011"^^<xsd:double>;
+  aqm:valor_a_las_9 "00021"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079039_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079039";
+  aqm:id_medicion "28079039_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00005"^^<xsd:double>;
+  aqm:valor_a_las_10 "00044"^^<xsd:double>;
+  aqm:valor_a_las_11 "00022"^^<xsd:double>;
+  aqm:valor_a_las_12 "00021"^^<xsd:double>;
+  aqm:valor_a_las_13 "00023"^^<xsd:double>;
+  aqm:valor_a_las_14 "00018"^^<xsd:double>;
+  aqm:valor_a_las_15 "00017"^^<xsd:double>;
+  aqm:valor_a_las_16 "00015"^^<xsd:double>;
+  aqm:valor_a_las_17 "00010"^^<xsd:double>;
+  aqm:valor_a_las_18 "00018"^^<xsd:double>;
+  aqm:valor_a_las_19 "00022"^^<xsd:double>;
+  aqm:valor_a_las_2 "00003"^^<xsd:double>;
+  aqm:valor_a_las_20 "00034"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00003"^^<xsd:double>;
+  aqm:valor_a_las_4 "00003"^^<xsd:double>;
+  aqm:valor_a_las_5 "00003"^^<xsd:double>;
+  aqm:valor_a_las_6 "00004"^^<xsd:double>;
+  aqm:valor_a_las_7 "00015"^^<xsd:double>;
+  aqm:valor_a_las_8 "00049"^^<xsd:double>;
+  aqm:valor_a_las_9 "00065"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079039_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079039";
+  aqm:id_medicion "28079039_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00007"^^<xsd:double>;
+  aqm:valor_a_las_10 "00060"^^<xsd:double>;
+  aqm:valor_a_las_11 "00030"^^<xsd:double>;
+  aqm:valor_a_las_12 "00029"^^<xsd:double>;
+  aqm:valor_a_las_13 "00031"^^<xsd:double>;
+  aqm:valor_a_las_14 "00026"^^<xsd:double>;
+  aqm:valor_a_las_15 "00024"^^<xsd:double>;
+  aqm:valor_a_las_16 "00023"^^<xsd:double>;
+  aqm:valor_a_las_17 "00012"^^<xsd:double>;
+  aqm:valor_a_las_18 "00021"^^<xsd:double>;
+  aqm:valor_a_las_19 "00025"^^<xsd:double>;
+  aqm:valor_a_las_2 "00004"^^<xsd:double>;
+  aqm:valor_a_las_20 "00036"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00004"^^<xsd:double>;
+  aqm:valor_a_las_4 "00004"^^<xsd:double>;
+  aqm:valor_a_las_5 "00005"^^<xsd:double>;
+  aqm:valor_a_las_6 "00005"^^<xsd:double>;
+  aqm:valor_a_las_7 "00018"^^<xsd:double>;
+  aqm:valor_a_las_8 "00066"^^<xsd:double>;
+  aqm:valor_a_las_9 "00098"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079039_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079039";
+  aqm:id_medicion "28079039_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "89.28"^^<xsd:double>;
+  aqm:valor_a_las_10 "40.92"^^<xsd:double>;
+  aqm:valor_a_las_11 "62.43"^^<xsd:double>;
+  aqm:valor_a_las_12 "64.30"^^<xsd:double>;
+  aqm:valor_a_las_13 "67.89"^^<xsd:double>;
+  aqm:valor_a_las_14 "78.33"^^<xsd:double>;
+  aqm:valor_a_las_15 "86.27"^^<xsd:double>;
+  aqm:valor_a_las_16 "94.36"^^<xsd:double>;
+  aqm:valor_a_las_17 "96.63"^^<xsd:double>;
+  aqm:valor_a_las_18 "89.56"^^<xsd:double>;
+  aqm:valor_a_las_19 "80.69"^^<xsd:double>;
+  aqm:valor_a_las_2 "88.92"^^<xsd:double>;
+  aqm:valor_a_las_20 "66.94"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "84.24"^^<xsd:double>;
+  aqm:valor_a_las_4 "78.46"^^<xsd:double>;
+  aqm:valor_a_las_5 "76.86"^^<xsd:double>;
+  aqm:valor_a_las_6 "76.22"^^<xsd:double>;
+  aqm:valor_a_las_7 "68.89"^^<xsd:double>;
+  aqm:valor_a_las_8 "37.19"^^<xsd:double>;
+  aqm:valor_a_las_9 "25.76"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079040_1_38> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Azufre";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079040";
+  aqm:id_medicion "28079040_1_38";
+  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00009"^^<xsd:double>;
+  aqm:valor_a_las_10 "00009"^^<xsd:double>;
+  aqm:valor_a_las_11 "00009"^^<xsd:double>;
+  aqm:valor_a_las_12 "00009"^^<xsd:double>;
+  aqm:valor_a_las_13 "00009"^^<xsd:double>;
+  aqm:valor_a_las_14 "00009"^^<xsd:double>;
+  aqm:valor_a_las_15 "00008"^^<xsd:double>;
+  aqm:valor_a_las_16 "00009"^^<xsd:double>;
+  aqm:valor_a_las_17 "00008"^^<xsd:double>;
+  aqm:valor_a_las_18 "00008"^^<xsd:double>;
+  aqm:valor_a_las_19 "00008"^^<xsd:double>;
+  aqm:valor_a_las_2 "00009"^^<xsd:double>;
+  aqm:valor_a_las_20 "00008"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00009"^^<xsd:double>;
+  aqm:valor_a_las_4 "00009"^^<xsd:double>;
+  aqm:valor_a_las_5 "00009"^^<xsd:double>;
+  aqm:valor_a_las_6 "00009"^^<xsd:double>;
+  aqm:valor_a_las_7 "00009"^^<xsd:double>;
+  aqm:valor_a_las_8 "00009"^^<xsd:double>;
+  aqm:valor_a_las_9 "00009"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Azufre> a
+    aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q5282" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FFluorescencia+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079040_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079040";
+  aqm:id_medicion "28079040_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00002"^^<xsd:double>;
+  aqm:valor_a_las_10 "00021"^^<xsd:double>;
+  aqm:valor_a_las_11 "00012"^^<xsd:double>;
+  aqm:valor_a_las_12 "00013"^^<xsd:double>;
+  aqm:valor_a_las_13 "00006"^^<xsd:double>;
+  aqm:valor_a_las_14 "00007"^^<xsd:double>;
+  aqm:valor_a_las_15 "00004"^^<xsd:double>;
+  aqm:valor_a_las_16 "00007"^^<xsd:double>;
+  aqm:valor_a_las_17 "00003"^^<xsd:double>;
+  aqm:valor_a_las_18 "00004"^^<xsd:double>;
+  aqm:valor_a_las_19 "00003"^^<xsd:double>;
+  aqm:valor_a_las_2 "00002"^^<xsd:double>;
+  aqm:valor_a_las_20 "00003"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00003"^^<xsd:double>;
+  aqm:valor_a_las_8 "00006"^^<xsd:double>;
+  aqm:valor_a_las_9 "00016"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079040_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079040";
+  aqm:id_medicion "28079040_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00013"^^<xsd:double>;
+  aqm:valor_a_las_10 "00060"^^<xsd:double>;
+  aqm:valor_a_las_11 "00040"^^<xsd:double>;
+  aqm:valor_a_las_12 "00038"^^<xsd:double>;
+  aqm:valor_a_las_13 "00019"^^<xsd:double>;
+  aqm:valor_a_las_14 "00020"^^<xsd:double>;
+  aqm:valor_a_las_15 "00015"^^<xsd:double>;
+  aqm:valor_a_las_16 "00022"^^<xsd:double>;
+  aqm:valor_a_las_17 "00014"^^<xsd:double>;
+  aqm:valor_a_las_18 "00018"^^<xsd:double>;
+  aqm:valor_a_las_19 "00018"^^<xsd:double>;
+  aqm:valor_a_las_2 "00011"^^<xsd:double>;
+  aqm:valor_a_las_20 "00029"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00005"^^<xsd:double>;
+  aqm:valor_a_las_4 "00005"^^<xsd:double>;
+  aqm:valor_a_las_5 "00005"^^<xsd:double>;
+  aqm:valor_a_las_6 "00009"^^<xsd:double>;
+  aqm:valor_a_las_7 "00019"^^<xsd:double>;
+  aqm:valor_a_las_8 "00036"^^<xsd:double>;
+  aqm:valor_a_las_9 "00058"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079040_10_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 10 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079040";
+  aqm:id_medicion "28079040_10_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00008"^^<xsd:double>;
+  aqm:valor_a_las_10 "00025"^^<xsd:double>;
+  aqm:valor_a_las_11 "00015"^^<xsd:double>;
+  aqm:valor_a_las_12 "00019"^^<xsd:double>;
+  aqm:valor_a_las_13 "00007"^^<xsd:double>;
+  aqm:valor_a_las_14 "00006"^^<xsd:double>;
+  aqm:valor_a_las_15 "00005"^^<xsd:double>;
+  aqm:valor_a_las_16 "00008"^^<xsd:double>;
+  aqm:valor_a_las_17 "00004"^^<xsd:double>;
+  aqm:valor_a_las_18 "00007"^^<xsd:double>;
+  aqm:valor_a_las_19 "00016"^^<xsd:double>;
+  aqm:valor_a_las_2 "00010"^^<xsd:double>;
+  aqm:valor_a_las_20 "00014"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00014"^^<xsd:double>;
+  aqm:valor_a_las_4 "00011"^^<xsd:double>;
+  aqm:valor_a_las_5 "00008"^^<xsd:double>;
+  aqm:valor_a_las_6 "00005"^^<xsd:double>;
+  aqm:valor_a_las_7 "00006"^^<xsd:double>;
+  aqm:valor_a_las_8 "00014"^^<xsd:double>;
+  aqm:valor_a_las_9 "00015"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+10+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Microbalanza> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079040_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079040";
+  aqm:id_medicion "28079040_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00015"^^<xsd:double>;
+  aqm:valor_a_las_10 "00092"^^<xsd:double>;
+  aqm:valor_a_las_11 "00059"^^<xsd:double>;
+  aqm:valor_a_las_12 "00057"^^<xsd:double>;
+  aqm:valor_a_las_13 "00028"^^<xsd:double>;
+  aqm:valor_a_las_14 "00031"^^<xsd:double>;
+  aqm:valor_a_las_15 "00022"^^<xsd:double>;
+  aqm:valor_a_las_16 "00033"^^<xsd:double>;
+  aqm:valor_a_las_17 "00018"^^<xsd:double>;
+  aqm:valor_a_las_18 "00025"^^<xsd:double>;
+  aqm:valor_a_las_19 "00023"^^<xsd:double>;
+  aqm:valor_a_las_2 "00014"^^<xsd:double>;
+  aqm:valor_a_las_20 "00034"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00007"^^<xsd:double>;
+  aqm:valor_a_las_4 "00006"^^<xsd:double>;
+  aqm:valor_a_las_5 "00006"^^<xsd:double>;
+  aqm:valor_a_las_6 "00010"^^<xsd:double>;
+  aqm:valor_a_las_7 "00024"^^<xsd:double>;
+  aqm:valor_a_las_8 "00046"^^<xsd:double>;
+  aqm:valor_a_las_9 "00082"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079047_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079047";
+  aqm:id_medicion "28079047_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00005"^^<xsd:double>;
+  aqm:valor_a_las_11 "00008"^^<xsd:double>;
+  aqm:valor_a_las_12 "00009"^^<xsd:double>;
+  aqm:valor_a_las_13 "00006"^^<xsd:double>;
+  aqm:valor_a_las_14 "00004"^^<xsd:double>;
+  aqm:valor_a_las_15 "00004"^^<xsd:double>;
+  aqm:valor_a_las_16 "00002"^^<xsd:double>;
+  aqm:valor_a_las_17 "00002"^^<xsd:double>;
+  aqm:valor_a_las_18 "00002"^^<xsd:double>;
+  aqm:valor_a_las_19 "00003"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00004"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00001"^^<xsd:double>;
+  aqm:valor_a_las_8 "00001"^^<xsd:double>;
+  aqm:valor_a_las_9 "00003"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079047_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079047";
+  aqm:id_medicion "28079047_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00016"^^<xsd:double>;
+  aqm:valor_a_las_10 "00045"^^<xsd:double>;
+  aqm:valor_a_las_11 "00037"^^<xsd:double>;
+  aqm:valor_a_las_12 "00033"^^<xsd:double>;
+  aqm:valor_a_las_13 "00026"^^<xsd:double>;
+  aqm:valor_a_las_14 "00019"^^<xsd:double>;
+  aqm:valor_a_las_15 "00021"^^<xsd:double>;
+  aqm:valor_a_las_16 "00017"^^<xsd:double>;
+  aqm:valor_a_las_17 "00019"^^<xsd:double>;
+  aqm:valor_a_las_18 "00021"^^<xsd:double>;
+  aqm:valor_a_las_19 "00030"^^<xsd:double>;
+  aqm:valor_a_las_2 "00013"^^<xsd:double>;
+  aqm:valor_a_las_20 "00042"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00006"^^<xsd:double>;
+  aqm:valor_a_las_4 "00005"^^<xsd:double>;
+  aqm:valor_a_las_5 "00004"^^<xsd:double>;
+  aqm:valor_a_las_6 "00007"^^<xsd:double>;
+  aqm:valor_a_las_7 "00013"^^<xsd:double>;
+  aqm:valor_a_las_8 "00027"^^<xsd:double>;
+  aqm:valor_a_las_9 "00045"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079047_9_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079047";
+  aqm:id_medicion "28079047_9_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00014"^^<xsd:double>;
+  aqm:valor_a_las_10 "00009"^^<xsd:double>;
+  aqm:valor_a_las_11 "00020"^^<xsd:double>;
+  aqm:valor_a_las_12 "00015"^^<xsd:double>;
+  aqm:valor_a_las_13 "00014"^^<xsd:double>;
+  aqm:valor_a_las_14 "00015"^^<xsd:double>;
+  aqm:valor_a_las_15 "00012"^^<xsd:double>;
+  aqm:valor_a_las_16 "00015"^^<xsd:double>;
+  aqm:valor_a_las_17 "00013"^^<xsd:double>;
+  aqm:valor_a_las_18 "00015"^^<xsd:double>;
+  aqm:valor_a_las_19 "00007"^^<xsd:double>;
+  aqm:valor_a_las_2 "00015"^^<xsd:double>;
+  aqm:valor_a_las_20 "00014"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00012"^^<xsd:double>;
+  aqm:valor_a_las_4 "00015"^^<xsd:double>;
+  aqm:valor_a_las_5 "00009"^^<xsd:double>;
+  aqm:valor_a_las_6 "00027"^^<xsd:double>;
+  aqm:valor_a_las_7 "00025"^^<xsd:double>;
+  aqm:valor_a_las_8 "00009"^^<xsd:double>;
+  aqm:valor_a_las_9 "00010"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+2.5+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Microbalanza> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079047_10_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 10 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079047";
+  aqm:id_medicion "28079047_10_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00020"^^<xsd:double>;
+  aqm:valor_a_las_10 "00017"^^<xsd:double>;
+  aqm:valor_a_las_11 "00028"^^<xsd:double>;
+  aqm:valor_a_las_12 "00020"^^<xsd:double>;
+  aqm:valor_a_las_13 "00021"^^<xsd:double>;
+  aqm:valor_a_las_14 "00023"^^<xsd:double>;
+  aqm:valor_a_las_15 "00020"^^<xsd:double>;
+  aqm:valor_a_las_16 "00021"^^<xsd:double>;
+  aqm:valor_a_las_17 "00018"^^<xsd:double>;
+  aqm:valor_a_las_18 "00020"^^<xsd:double>;
+  aqm:valor_a_las_19 "00012"^^<xsd:double>;
+  aqm:valor_a_las_2 "00021"^^<xsd:double>;
+  aqm:valor_a_las_20 "00020"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00016"^^<xsd:double>;
+  aqm:valor_a_las_4 "00020"^^<xsd:double>;
+  aqm:valor_a_las_5 "00014"^^<xsd:double>;
+  aqm:valor_a_las_6 "00029"^^<xsd:double>;
+  aqm:valor_a_las_7 "00028"^^<xsd:double>;
+  aqm:valor_a_las_8 "00014"^^<xsd:double>;
+  aqm:valor_a_las_9 "00015"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+10+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079047_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079047";
+  aqm:id_medicion "28079047_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00017"^^<xsd:double>;
+  aqm:valor_a_las_10 "00053"^^<xsd:double>;
+  aqm:valor_a_las_11 "00048"^^<xsd:double>;
+  aqm:valor_a_las_12 "00046"^^<xsd:double>;
+  aqm:valor_a_las_13 "00036"^^<xsd:double>;
+  aqm:valor_a_las_14 "00025"^^<xsd:double>;
+  aqm:valor_a_las_15 "00027"^^<xsd:double>;
+  aqm:valor_a_las_16 "00020"^^<xsd:double>;
+  aqm:valor_a_las_17 "00022"^^<xsd:double>;
+  aqm:valor_a_las_18 "00025"^^<xsd:double>;
+  aqm:valor_a_las_19 "00035"^^<xsd:double>;
+  aqm:valor_a_las_2 "00015"^^<xsd:double>;
+  aqm:valor_a_las_20 "00048"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00007"^^<xsd:double>;
+  aqm:valor_a_las_4 "00006"^^<xsd:double>;
+  aqm:valor_a_las_5 "00006"^^<xsd:double>;
+  aqm:valor_a_las_6 "00008"^^<xsd:double>;
+  aqm:valor_a_las_7 "00014"^^<xsd:double>;
+  aqm:valor_a_las_8 "00028"^^<xsd:double>;
+  aqm:valor_a_las_9 "00049"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079048_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079048";
+  aqm:id_medicion "28079048_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00020"^^<xsd:double>;
+  aqm:valor_a_las_11 "00004"^^<xsd:double>;
+  aqm:valor_a_las_12 "00004"^^<xsd:double>;
+  aqm:valor_a_las_13 "00004"^^<xsd:double>;
+  aqm:valor_a_las_14 "00004"^^<xsd:double>;
+  aqm:valor_a_las_15 "00004"^^<xsd:double>;
+  aqm:valor_a_las_16 "00003"^^<xsd:double>;
+  aqm:valor_a_las_17 "00003"^^<xsd:double>;
+  aqm:valor_a_las_18 "00001"^^<xsd:double>;
+  aqm:valor_a_las_19 "00001"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00001"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00001"^^<xsd:double>;
+  aqm:valor_a_las_8 "00009"^^<xsd:double>;
+  aqm:valor_a_las_9 "00019"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079048_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079048";
+  aqm:id_medicion "28079048_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00009"^^<xsd:double>;
+  aqm:valor_a_las_10 "00047"^^<xsd:double>;
+  aqm:valor_a_las_11 "00019"^^<xsd:double>;
+  aqm:valor_a_las_12 "00019"^^<xsd:double>;
+  aqm:valor_a_las_13 "00014"^^<xsd:double>;
+  aqm:valor_a_las_14 "00015"^^<xsd:double>;
+  aqm:valor_a_las_15 "00017"^^<xsd:double>;
+  aqm:valor_a_las_16 "00012"^^<xsd:double>;
+  aqm:valor_a_las_17 "00011"^^<xsd:double>;
+  aqm:valor_a_las_18 "00007"^^<xsd:double>;
+  aqm:valor_a_las_19 "00010"^^<xsd:double>;
+  aqm:valor_a_las_2 "00005"^^<xsd:double>;
+  aqm:valor_a_las_20 "00018"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00002"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00003"^^<xsd:double>;
+  aqm:valor_a_las_7 "00011"^^<xsd:double>;
+  aqm:valor_a_las_8 "00037"^^<xsd:double>;
+  aqm:valor_a_las_9 "00054"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079048_9_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079048";
+  aqm:id_medicion "28079048_9_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00006"^^<xsd:double>;
+  aqm:valor_a_las_10 "00005"^^<xsd:double>;
+  aqm:valor_a_las_11 "00007"^^<xsd:double>;
+  aqm:valor_a_las_12 "00006"^^<xsd:double>;
+  aqm:valor_a_las_13 "00005"^^<xsd:double>;
+  aqm:valor_a_las_14 "00016"^^<xsd:double>;
+  aqm:valor_a_las_15 "00008"^^<xsd:double>;
+  aqm:valor_a_las_16 "00005"^^<xsd:double>;
+  aqm:valor_a_las_17 "00005"^^<xsd:double>;
+  aqm:valor_a_las_18 "00009"^^<xsd:double>;
+  aqm:valor_a_las_19 "00001"^^<xsd:double>;
+  aqm:valor_a_las_2 "00004"^^<xsd:double>;
+  aqm:valor_a_las_20 "00005"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00006"^^<xsd:double>;
+  aqm:valor_a_las_4 "00006"^^<xsd:double>;
+  aqm:valor_a_las_5 "00005"^^<xsd:double>;
+  aqm:valor_a_las_6 "00008"^^<xsd:double>;
+  aqm:valor_a_las_7 "00003"^^<xsd:double>;
+  aqm:valor_a_las_8 "00002"^^<xsd:double>;
+  aqm:valor_a_las_9 "00004"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+2.5+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Microbalanza> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079048_10_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 10 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079048";
+  aqm:id_medicion "28079048_10_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00010"^^<xsd:double>;
+  aqm:valor_a_las_10 "00014"^^<xsd:double>;
+  aqm:valor_a_las_11 "00016"^^<xsd:double>;
+  aqm:valor_a_las_12 "00011"^^<xsd:double>;
+  aqm:valor_a_las_13 "00011"^^<xsd:double>;
+  aqm:valor_a_las_14 "00022"^^<xsd:double>;
+  aqm:valor_a_las_15 "00015"^^<xsd:double>;
+  aqm:valor_a_las_16 "00011"^^<xsd:double>;
+  aqm:valor_a_las_17 "00009"^^<xsd:double>;
+  aqm:valor_a_las_18 "00014"^^<xsd:double>;
+  aqm:valor_a_las_19 "00003"^^<xsd:double>;
+  aqm:valor_a_las_2 "00009"^^<xsd:double>;
+  aqm:valor_a_las_20 "00007"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00012"^^<xsd:double>;
+  aqm:valor_a_las_4 "00010"^^<xsd:double>;
+  aqm:valor_a_las_5 "00010"^^<xsd:double>;
+  aqm:valor_a_las_6 "00013"^^<xsd:double>;
+  aqm:valor_a_las_7 "00008"^^<xsd:double>;
+  aqm:valor_a_las_8 "00007"^^<xsd:double>;
+  aqm:valor_a_las_9 "00012"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+10+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079048_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079048";
+  aqm:id_medicion "28079048_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00011"^^<xsd:double>;
+  aqm:valor_a_las_10 "00078"^^<xsd:double>;
+  aqm:valor_a_las_11 "00025"^^<xsd:double>;
+  aqm:valor_a_las_12 "00025"^^<xsd:double>;
+  aqm:valor_a_las_13 "00020"^^<xsd:double>;
+  aqm:valor_a_las_14 "00022"^^<xsd:double>;
+  aqm:valor_a_las_15 "00023"^^<xsd:double>;
+  aqm:valor_a_las_16 "00016"^^<xsd:double>;
+  aqm:valor_a_las_17 "00015"^^<xsd:double>;
+  aqm:valor_a_las_18 "00009"^^<xsd:double>;
+  aqm:valor_a_las_19 "00012"^^<xsd:double>;
+  aqm:valor_a_las_2 "00006"^^<xsd:double>;
+  aqm:valor_a_las_20 "00019"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00004"^^<xsd:double>;
+  aqm:valor_a_las_4 "00003"^^<xsd:double>;
+  aqm:valor_a_las_5 "00003"^^<xsd:double>;
+  aqm:valor_a_las_6 "00004"^^<xsd:double>;
+  aqm:valor_a_las_7 "00013"^^<xsd:double>;
+  aqm:valor_a_las_8 "00050"^^<xsd:double>;
+  aqm:valor_a_las_9 "00083"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079049_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079049";
+  aqm:id_medicion "28079049_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00005"^^<xsd:double>;
+  aqm:valor_a_las_11 "00008"^^<xsd:double>;
+  aqm:valor_a_las_12 "00004"^^<xsd:double>;
+  aqm:valor_a_las_13 "00001"^^<xsd:double>;
+  aqm:valor_a_las_14 "00001"^^<xsd:double>;
+  aqm:valor_a_las_15 "00001"^^<xsd:double>;
+  aqm:valor_a_las_16 "00001"^^<xsd:double>;
+  aqm:valor_a_las_17 "00001"^^<xsd:double>;
+  aqm:valor_a_las_18 "00001"^^<xsd:double>;
+  aqm:valor_a_las_19 "00001"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00001"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00001"^^<xsd:double>;
+  aqm:valor_a_las_8 "00001"^^<xsd:double>;
+  aqm:valor_a_las_9 "00001"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079049_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079049";
+  aqm:id_medicion "28079049_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00006"^^<xsd:double>;
+  aqm:valor_a_las_10 "00034"^^<xsd:double>;
+  aqm:valor_a_las_11 "00031"^^<xsd:double>;
+  aqm:valor_a_las_12 "00031"^^<xsd:double>;
+  aqm:valor_a_las_13 "00012"^^<xsd:double>;
+  aqm:valor_a_las_14 "00013"^^<xsd:double>;
+  aqm:valor_a_las_15 "00012"^^<xsd:double>;
+  aqm:valor_a_las_16 "00011"^^<xsd:double>;
+  aqm:valor_a_las_17 "00008"^^<xsd:double>;
+  aqm:valor_a_las_18 "00007"^^<xsd:double>;
+  aqm:valor_a_las_19 "00010"^^<xsd:double>;
+  aqm:valor_a_las_2 "00004"^^<xsd:double>;
+  aqm:valor_a_las_20 "00014"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00003"^^<xsd:double>;
+  aqm:valor_a_las_4 "00002"^^<xsd:double>;
+  aqm:valor_a_las_5 "00002"^^<xsd:double>;
+  aqm:valor_a_las_6 "00003"^^<xsd:double>;
+  aqm:valor_a_las_7 "00006"^^<xsd:double>;
+  aqm:valor_a_las_8 "00017"^^<xsd:double>;
+  aqm:valor_a_las_9 "00037"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079049_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079049";
+  aqm:id_medicion "28079049_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00008"^^<xsd:double>;
+  aqm:valor_a_las_10 "00042"^^<xsd:double>;
+  aqm:valor_a_las_11 "00044"^^<xsd:double>;
+  aqm:valor_a_las_12 "00038"^^<xsd:double>;
+  aqm:valor_a_las_13 "00014"^^<xsd:double>;
+  aqm:valor_a_las_14 "00015"^^<xsd:double>;
+  aqm:valor_a_las_15 "00013"^^<xsd:double>;
+  aqm:valor_a_las_16 "00012"^^<xsd:double>;
+  aqm:valor_a_las_17 "00009"^^<xsd:double>;
+  aqm:valor_a_las_18 "00009"^^<xsd:double>;
+  aqm:valor_a_las_19 "00011"^^<xsd:double>;
+  aqm:valor_a_las_2 "00006"^^<xsd:double>;
+  aqm:valor_a_las_20 "00015"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00004"^^<xsd:double>;
+  aqm:valor_a_las_4 "00003"^^<xsd:double>;
+  aqm:valor_a_las_5 "00004"^^<xsd:double>;
+  aqm:valor_a_las_6 "00005"^^<xsd:double>;
+  aqm:valor_a_las_7 "00008"^^<xsd:double>;
+  aqm:valor_a_las_8 "00018"^^<xsd:double>;
+  aqm:valor_a_las_9 "00039"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079049_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079049";
+  aqm:id_medicion "28079049_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "75.97"^^<xsd:double>;
+  aqm:valor_a_las_10 "34.15"^^<xsd:double>;
+  aqm:valor_a_las_11 "51.32"^^<xsd:double>;
+  aqm:valor_a_las_12 "49.58"^^<xsd:double>;
+  aqm:valor_a_las_13 "66.90"^^<xsd:double>;
+  aqm:valor_a_las_14 "69.59"^^<xsd:double>;
+  aqm:valor_a_las_15 "78.47"^^<xsd:double>;
+  aqm:valor_a_las_16 "85.34"^^<xsd:double>;
+  aqm:valor_a_las_17 "89.27"^^<xsd:double>;
+  aqm:valor_a_las_18 "86.68"^^<xsd:double>;
+  aqm:valor_a_las_19 "80.85"^^<xsd:double>;
+  aqm:valor_a_las_2 "76.60"^^<xsd:double>;
+  aqm:valor_a_las_20 "67.50"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "72.02"^^<xsd:double>;
+  aqm:valor_a_las_4 "75.74"^^<xsd:double>;
+  aqm:valor_a_las_5 "71.86"^^<xsd:double>;
+  aqm:valor_a_las_6 "69.30"^^<xsd:double>;
+  aqm:valor_a_las_7 "66.68"^^<xsd:double>;
+  aqm:valor_a_las_8 "54.10"^^<xsd:double>;
+  aqm:valor_a_las_9 "33.38"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079050_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079050";
+  aqm:id_medicion "28079050_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00003"^^<xsd:double>;
+  aqm:valor_a_las_10 "00056"^^<xsd:double>;
+  aqm:valor_a_las_11 "00011"^^<xsd:double>;
+  aqm:valor_a_las_12 "00005"^^<xsd:double>;
+  aqm:valor_a_las_13 "00013"^^<xsd:double>;
+  aqm:valor_a_las_14 "00012"^^<xsd:double>;
+  aqm:valor_a_las_15 "00015"^^<xsd:double>;
+  aqm:valor_a_las_16 "00013"^^<xsd:double>;
+  aqm:valor_a_las_17 "00011"^^<xsd:double>;
+  aqm:valor_a_las_18 "00006"^^<xsd:double>;
+  aqm:valor_a_las_19 "00002"^^<xsd:double>;
+  aqm:valor_a_las_2 "00002"^^<xsd:double>;
+  aqm:valor_a_las_20 "00003"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00002"^^<xsd:double>;
+  aqm:valor_a_las_4 "00003"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00004"^^<xsd:double>;
+  aqm:valor_a_las_7 "00018"^^<xsd:double>;
+  aqm:valor_a_las_8 "00063"^^<xsd:double>;
+  aqm:valor_a_las_9 "00056"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079050_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079050";
+  aqm:id_medicion "28079050_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00008"^^<xsd:double>;
+  aqm:valor_a_las_10 "00066"^^<xsd:double>;
+  aqm:valor_a_las_11 "00023"^^<xsd:double>;
+  aqm:valor_a_las_12 "00015"^^<xsd:double>;
+  aqm:valor_a_las_13 "00024"^^<xsd:double>;
+  aqm:valor_a_las_14 "00022"^^<xsd:double>;
+  aqm:valor_a_las_15 "00026"^^<xsd:double>;
+  aqm:valor_a_las_16 "00023"^^<xsd:double>;
+  aqm:valor_a_las_17 "00022"^^<xsd:double>;
+  aqm:valor_a_las_18 "00017"^^<xsd:double>;
+  aqm:valor_a_las_19 "00017"^^<xsd:double>;
+  aqm:valor_a_las_2 "00005"^^<xsd:double>;
+  aqm:valor_a_las_20 "00031"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00004"^^<xsd:double>;
+  aqm:valor_a_las_4 "00004"^^<xsd:double>;
+  aqm:valor_a_las_5 "00003"^^<xsd:double>;
+  aqm:valor_a_las_6 "00007"^^<xsd:double>;
+  aqm:valor_a_las_7 "00028"^^<xsd:double>;
+  aqm:valor_a_las_8 "00071"^^<xsd:double>;
+  aqm:valor_a_las_9 "00072"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079050_9_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079050";
+  aqm:id_medicion "28079050_9_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00005"^^<xsd:double>;
+  aqm:valor_a_las_10 "00007"^^<xsd:double>;
+  aqm:valor_a_las_11 "00009"^^<xsd:double>;
+  aqm:valor_a_las_12 "00005"^^<xsd:double>;
+  aqm:valor_a_las_13 "00004"^^<xsd:double>;
+  aqm:valor_a_las_14 "00022"^^<xsd:double>;
+  aqm:valor_a_las_15 "00002"^^<xsd:double>;
+  aqm:valor_a_las_16 "00001"^^<xsd:double>;
+  aqm:valor_a_las_17 "00003"^^<xsd:double>;
+  aqm:valor_a_las_18 "00006"^^<xsd:double>;
+  aqm:valor_a_las_19 "00006"^^<xsd:double>;
+  aqm:valor_a_las_2 "00008"^^<xsd:double>;
+  aqm:valor_a_las_20 "00006"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00012"^^<xsd:double>;
+  aqm:valor_a_las_4 "00006"^^<xsd:double>;
+  aqm:valor_a_las_5 "00002"^^<xsd:double>;
+  aqm:valor_a_las_6 "00002"^^<xsd:double>;
+  aqm:valor_a_las_7 "00006"^^<xsd:double>;
+  aqm:valor_a_las_8 "00005"^^<xsd:double>;
+  aqm:valor_a_las_9 "00007"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+2.5+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Microbalanza> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569";
+  a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079050_10_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 10 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079050";
+  aqm:id_medicion "28079050_10_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00013"^^<xsd:double>;
+  aqm:valor_a_las_10 "00021"^^<xsd:double>;
+  aqm:valor_a_las_11 "00021"^^<xsd:double>;
+  aqm:valor_a_las_12 "00015"^^<xsd:double>;
+  aqm:valor_a_las_13 "00012"^^<xsd:double>;
+  aqm:valor_a_las_14 "00030"^^<xsd:double>;
+  aqm:valor_a_las_15 "00007"^^<xsd:double>;
+  aqm:valor_a_las_16 "00008"^^<xsd:double>;
+  aqm:valor_a_las_17 "00011"^^<xsd:double>;
+  aqm:valor_a_las_18 "00015"^^<xsd:double>;
+  aqm:valor_a_las_19 "00014"^^<xsd:double>;
+  aqm:valor_a_las_2 "00016"^^<xsd:double>;
+  aqm:valor_a_las_20 "00013"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00020"^^<xsd:double>;
+  aqm:valor_a_las_4 "00015"^^<xsd:double>;
+  aqm:valor_a_las_5 "00010"^^<xsd:double>;
+  aqm:valor_a_las_6 "00008"^^<xsd:double>;
+  aqm:valor_a_las_7 "00014"^^<xsd:double>;
+  aqm:valor_a_las_8 "00015"^^<xsd:double>;
+  aqm:valor_a_las_9 "00019"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+10+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079050_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079050";
+  aqm:id_medicion "28079050_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00012"^^<xsd:double>;
+  aqm:valor_a_las_10 "00153"^^<xsd:double>;
+  aqm:valor_a_las_11 "00040"^^<xsd:double>;
+  aqm:valor_a_las_12 "00023"^^<xsd:double>;
+  aqm:valor_a_las_13 "00045"^^<xsd:double>;
+  aqm:valor_a_las_14 "00041"^^<xsd:double>;
+  aqm:valor_a_las_15 "00048"^^<xsd:double>;
+  aqm:valor_a_las_16 "00042"^^<xsd:double>;
+  aqm:valor_a_las_17 "00038"^^<xsd:double>;
+  aqm:valor_a_las_18 "00027"^^<xsd:double>;
+  aqm:valor_a_las_19 "00020"^^<xsd:double>;
+  aqm:valor_a_las_2 "00008"^^<xsd:double>;
+  aqm:valor_a_las_20 "00035"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00006"^^<xsd:double>;
+  aqm:valor_a_las_4 "00008"^^<xsd:double>;
+  aqm:valor_a_las_5 "00005"^^<xsd:double>;
+  aqm:valor_a_las_6 "00012"^^<xsd:double>;
+  aqm:valor_a_las_7 "00057"^^<xsd:double>;
+  aqm:valor_a_las_8 "00167"^^<xsd:double>;
+  aqm:valor_a_las_9 "00157"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079054_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079054";
+  aqm:id_medicion "28079054_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00023"^^<xsd:double>;
+  aqm:valor_a_las_11 "00020"^^<xsd:double>;
+  aqm:valor_a_las_12 "00010"^^<xsd:double>;
+  aqm:valor_a_las_13 "00003"^^<xsd:double>;
+  aqm:valor_a_las_14 "00002"^^<xsd:double>;
+  aqm:valor_a_las_15 "00002"^^<xsd:double>;
+  aqm:valor_a_las_16 "00002"^^<xsd:double>;
+  aqm:valor_a_las_17 "00003"^^<xsd:double>;
+  aqm:valor_a_las_18 "00003"^^<xsd:double>;
+  aqm:valor_a_las_19 "00004"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00004"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00001"^^<xsd:double>;
+  aqm:valor_a_las_8 "00001"^^<xsd:double>;
+  aqm:valor_a_las_9 "00010"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079054_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079054";
+  aqm:id_medicion "28079054_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00016"^^<xsd:double>;
+  aqm:valor_a_las_10 "00077"^^<xsd:double>;
+  aqm:valor_a_las_11 "00060"^^<xsd:double>;
+  aqm:valor_a_las_12 "00039"^^<xsd:double>;
+  aqm:valor_a_las_13 "00021"^^<xsd:double>;
+  aqm:valor_a_las_14 "00021"^^<xsd:double>;
+  aqm:valor_a_las_15 "00020"^^<xsd:double>;
+  aqm:valor_a_las_16 "00021"^^<xsd:double>;
+  aqm:valor_a_las_17 "00025"^^<xsd:double>;
+  aqm:valor_a_las_18 "00025"^^<xsd:double>;
+  aqm:valor_a_las_19 "00031"^^<xsd:double>;
+  aqm:valor_a_las_2 "00013"^^<xsd:double>;
+  aqm:valor_a_las_20 "00045"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00010"^^<xsd:double>;
+  aqm:valor_a_las_4 "00011"^^<xsd:double>;
+  aqm:valor_a_las_5 "00010"^^<xsd:double>;
+  aqm:valor_a_las_6 "00011"^^<xsd:double>;
+  aqm:valor_a_las_7 "00020"^^<xsd:double>;
+  aqm:valor_a_las_8 "00033"^^<xsd:double>;
+  aqm:valor_a_las_9 "00067"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079054_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079054";
+  aqm:id_medicion "28079054_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00018"^^<xsd:double>;
+  aqm:valor_a_las_10 "00112"^^<xsd:double>;
+  aqm:valor_a_las_11 "00091"^^<xsd:double>;
+  aqm:valor_a_las_12 "00053"^^<xsd:double>;
+  aqm:valor_a_las_13 "00025"^^<xsd:double>;
+  aqm:valor_a_las_14 "00024"^^<xsd:double>;
+  aqm:valor_a_las_15 "00023"^^<xsd:double>;
+  aqm:valor_a_las_16 "00024"^^<xsd:double>;
+  aqm:valor_a_las_17 "00029"^^<xsd:double>;
+  aqm:valor_a_las_18 "00029"^^<xsd:double>;
+  aqm:valor_a_las_19 "00037"^^<xsd:double>;
+  aqm:valor_a_las_2 "00015"^^<xsd:double>;
+  aqm:valor_a_las_20 "00051"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00012"^^<xsd:double>;
+  aqm:valor_a_las_4 "00012"^^<xsd:double>;
+  aqm:valor_a_las_5 "00012"^^<xsd:double>;
+  aqm:valor_a_las_6 "00013"^^<xsd:double>;
+  aqm:valor_a_las_7 "00021"^^<xsd:double>;
+  aqm:valor_a_las_8 "00034"^^<xsd:double>;
+  aqm:valor_a_las_9 "00081"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079054_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079054";
+  aqm:id_medicion "28079054_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "71.27"^^<xsd:double>;
+  aqm:valor_a_las_10 "19.32"^^<xsd:double>;
+  aqm:valor_a_las_11 "34.35"^^<xsd:double>;
+  aqm:valor_a_las_12 "51.76"^^<xsd:double>;
+  aqm:valor_a_las_13 "67.66"^^<xsd:double>;
+  aqm:valor_a_las_14 "73.13"^^<xsd:double>;
+  aqm:valor_a_las_15 "77.39"^^<xsd:double>;
+  aqm:valor_a_las_16 "84.09"^^<xsd:double>;
+  aqm:valor_a_las_17 "80.70"^^<xsd:double>;
+  aqm:valor_a_las_18 "79.45"^^<xsd:double>;
+  aqm:valor_a_las_19 "72.25"^^<xsd:double>;
+  aqm:valor_a_las_2 "76.23"^^<xsd:double>;
+  aqm:valor_a_las_20 "56.63"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "75.80"^^<xsd:double>;
+  aqm:valor_a_las_4 "73.52"^^<xsd:double>;
+  aqm:valor_a_las_5 "70.24"^^<xsd:double>;
+  aqm:valor_a_las_6 "67.11"^^<xsd:double>;
+  aqm:valor_a_las_7 "59.79"^^<xsd:double>;
+  aqm:valor_a_las_8 "46.92"^^<xsd:double>;
+  aqm:valor_a_las_9 "21.71"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079055_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079055";
+  aqm:id_medicion "28079055_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00003"^^<xsd:double>;
+  aqm:valor_a_las_10 "00075"^^<xsd:double>;
+  aqm:valor_a_las_11 "00020"^^<xsd:double>;
+  aqm:valor_a_las_12 "00005"^^<xsd:double>;
+  aqm:valor_a_las_13 "00005"^^<xsd:double>;
+  aqm:valor_a_las_14 "00004"^^<xsd:double>;
+  aqm:valor_a_las_15 "00003"^^<xsd:double>;
+  aqm:valor_a_las_16 "00003"^^<xsd:double>;
+  aqm:valor_a_las_17 "00003"^^<xsd:double>;
+  aqm:valor_a_las_18 "00003"^^<xsd:double>;
+  aqm:valor_a_las_19 "00004"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00003"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00002"^^<xsd:double>;
+  aqm:valor_a_las_8 "00006"^^<xsd:double>;
+  aqm:valor_a_las_9 "00092"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079055_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079055";
+  aqm:id_medicion "28079055_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00043"^^<xsd:double>;
+  aqm:valor_a_las_10 "00071"^^<xsd:double>;
+  aqm:valor_a_las_11 "00044"^^<xsd:double>;
+  aqm:valor_a_las_12 "00015"^^<xsd:double>;
+  aqm:valor_a_las_13 "00014"^^<xsd:double>;
+  aqm:valor_a_las_14 "00014"^^<xsd:double>;
+  aqm:valor_a_las_15 "00009"^^<xsd:double>;
+  aqm:valor_a_las_16 "00012"^^<xsd:double>;
+  aqm:valor_a_las_17 "00013"^^<xsd:double>;
+  aqm:valor_a_las_18 "00014"^^<xsd:double>;
+  aqm:valor_a_las_19 "00019"^^<xsd:double>;
+  aqm:valor_a_las_2 "00035"^^<xsd:double>;
+  aqm:valor_a_las_20 "00029"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00009"^^<xsd:double>;
+  aqm:valor_a_las_4 "00003"^^<xsd:double>;
+  aqm:valor_a_las_5 "00003"^^<xsd:double>;
+  aqm:valor_a_las_6 "00006"^^<xsd:double>;
+  aqm:valor_a_las_7 "00023"^^<xsd:double>;
+  aqm:valor_a_las_8 "00045"^^<xsd:double>;
+  aqm:valor_a_las_9 "00086"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079055_10_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 10 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079055";
+  aqm:id_medicion "28079055_10_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00002"^^<xsd:double>;
+  aqm:valor_a_las_11 "00001"^^<xsd:double>;
+  aqm:valor_a_las_12 "00012"^^<xsd:double>;
+  aqm:valor_a_las_13 "00015"^^<xsd:double>;
+  aqm:valor_a_las_14 "00012"^^<xsd:double>;
+  aqm:valor_a_las_15 "00004"^^<xsd:double>;
+  aqm:valor_a_las_16 "00007"^^<xsd:double>;
+  aqm:valor_a_las_17 "00004"^^<xsd:double>;
+  aqm:valor_a_las_18 "00005"^^<xsd:double>;
+  aqm:valor_a_las_19 "00001"^^<xsd:double>;
+  aqm:valor_a_las_2 "00002"^^<xsd:double>;
+  aqm:valor_a_las_20 "00013"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00002"^^<xsd:double>;
+  aqm:valor_a_las_8 "00001"^^<xsd:double>;
+  aqm:valor_a_las_9 "00002"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+10+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Microbalanza> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079055_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079055";
+  aqm:id_medicion "28079055_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00048"^^<xsd:double>;
+  aqm:valor_a_las_10 "00185"^^<xsd:double>;
+  aqm:valor_a_las_11 "00075"^^<xsd:double>;
+  aqm:valor_a_las_12 "00022"^^<xsd:double>;
+  aqm:valor_a_las_13 "00021"^^<xsd:double>;
+  aqm:valor_a_las_14 "00020"^^<xsd:double>;
+  aqm:valor_a_las_15 "00013"^^<xsd:double>;
+  aqm:valor_a_las_16 "00017"^^<xsd:double>;
+  aqm:valor_a_las_17 "00017"^^<xsd:double>;
+  aqm:valor_a_las_18 "00019"^^<xsd:double>;
+  aqm:valor_a_las_19 "00025"^^<xsd:double>;
+  aqm:valor_a_las_2 "00037"^^<xsd:double>;
+  aqm:valor_a_las_20 "00034"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00010"^^<xsd:double>;
+  aqm:valor_a_las_4 "00004"^^<xsd:double>;
+  aqm:valor_a_las_5 "00005"^^<xsd:double>;
+  aqm:valor_a_las_6 "00008"^^<xsd:double>;
+  aqm:valor_a_las_7 "00026"^^<xsd:double>;
+  aqm:valor_a_las_8 "00055"^^<xsd:double>;
+  aqm:valor_a_las_9 "00226"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079055_20_59> a aqm:Measurement;
+  aqm:contaminante "Tolueno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079055";
+  aqm:id_medicion "28079055_20_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "000.4"^^<xsd:double>;
+  aqm:valor_a_las_10 "001.7"^^<xsd:double>;
+  aqm:valor_a_las_11 "001.4"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.6"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_2 "001.9"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "002.8"^^<xsd:double>;
+  aqm:valor_a_las_4 "001.8"^^<xsd:double>;
+  aqm:valor_a_las_5 "001.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.7"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.5"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.7"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.8"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Tolueno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q15779" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FCromatograf%C3%ADa+de+gases> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079055_30_59> a aqm:Measurement;
+  aqm:contaminante "Benceno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079055";
+  aqm:id_medicion "28079055_30_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.9"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.2"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Benceno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2270" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FCromatograf%C3%ADa+de+gases> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079055_35_59> a aqm:Measurement;
+  aqm:contaminante "Etilbenceno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079055";
+  aqm:id_medicion "28079055_35_59";
+  aqm:tecnica "Cromatografía de gases";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.1"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Etilbenceno> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q409184" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FCromatograf%C3%ADa+de+gases> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q677065" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079055_42_2> a aqm:Measurement;
+  aqm:contaminante "Hidrocarburos totales (hexano)";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079055";
+  aqm:id_medicion "28079055_42_2";
+  aqm:tecnica "Ionización de llama";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "01.53"^^<xsd:double>;
+  aqm:valor_a_las_10 "01.85"^^<xsd:double>;
+  aqm:valor_a_las_11 "01.64"^^<xsd:double>;
+  aqm:valor_a_las_12 "01.53"^^<xsd:double>;
+  aqm:valor_a_las_13 "01.51"^^<xsd:double>;
+  aqm:valor_a_las_14 "01.51"^^<xsd:double>;
+  aqm:valor_a_las_15 "01.51"^^<xsd:double>;
+  aqm:valor_a_las_16 "01.50"^^<xsd:double>;
+  aqm:valor_a_las_17 "01.50"^^<xsd:double>;
+  aqm:valor_a_las_18 "01.51"^^<xsd:double>;
+  aqm:valor_a_las_19 "01.51"^^<xsd:double>;
+  aqm:valor_a_las_2 "01.55"^^<xsd:double>;
+  aqm:valor_a_las_20 "01.52"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "01.51"^^<xsd:double>;
+  aqm:valor_a_las_4 "01.50"^^<xsd:double>;
+  aqm:valor_a_las_5 "01.50"^^<xsd:double>;
+  aqm:valor_a_las_6 "01.51"^^<xsd:double>;
+  aqm:valor_a_las_7 "01.51"^^<xsd:double>;
+  aqm:valor_a_las_8 "01.54"^^<xsd:double>;
+  aqm:valor_a_las_9 "01.72"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FHidrocarburos+totales+%28hexano%29>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FIonizaci%C3%B3n+de+llama> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q873305" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079055_43_2> a aqm:Measurement;
+  aqm:contaminante "Metano";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079055";
+  aqm:id_medicion "28079055_43_2";
+  aqm:tecnica "Ionización de llama";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "01.39"^^<xsd:double>;
+  aqm:valor_a_las_10 "01.60"^^<xsd:double>;
+  aqm:valor_a_las_11 "01.47"^^<xsd:double>;
+  aqm:valor_a_las_12 "01.40"^^<xsd:double>;
+  aqm:valor_a_las_13 "01.38"^^<xsd:double>;
+  aqm:valor_a_las_14 "01.38"^^<xsd:double>;
+  aqm:valor_a_las_15 "01.36"^^<xsd:double>;
+  aqm:valor_a_las_16 "01.35"^^<xsd:double>;
+  aqm:valor_a_las_17 "01.36"^^<xsd:double>;
+  aqm:valor_a_las_18 "01.36"^^<xsd:double>;
+  aqm:valor_a_las_19 "01.36"^^<xsd:double>;
+  aqm:valor_a_las_2 "01.40"^^<xsd:double>;
+  aqm:valor_a_las_20 "01.38"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "01.39"^^<xsd:double>;
+  aqm:valor_a_las_4 "01.41"^^<xsd:double>;
+  aqm:valor_a_las_5 "01.40"^^<xsd:double>;
+  aqm:valor_a_las_6 "01.40"^^<xsd:double>;
+  aqm:valor_a_las_7 "01.39"^^<xsd:double>;
+  aqm:valor_a_las_8 "01.40"^^<xsd:double>;
+  aqm:valor_a_las_9 "01.48"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Metano> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q37129" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FIonizaci%C3%B3n+de+llama> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q873305";
+  a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q873305" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079055_44_2> a aqm:Measurement;
+  aqm:contaminante "Hidrocarburos no metánicos (hexano)";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079055";
+  aqm:id_medicion "28079055_44_2";
+  aqm:tecnica "Ionización de llama";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "00.13"^^<xsd:double>;
+  aqm:valor_a_las_10 "00.24"^^<xsd:double>;
+  aqm:valor_a_las_11 "00.17"^^<xsd:double>;
+  aqm:valor_a_las_12 "00.13"^^<xsd:double>;
+  aqm:valor_a_las_13 "00.13"^^<xsd:double>;
+  aqm:valor_a_las_14 "00.14"^^<xsd:double>;
+  aqm:valor_a_las_15 "00.15"^^<xsd:double>;
+  aqm:valor_a_las_16 "00.16"^^<xsd:double>;
+  aqm:valor_a_las_17 "00.15"^^<xsd:double>;
+  aqm:valor_a_las_18 "00.15"^^<xsd:double>;
+  aqm:valor_a_las_19 "00.15"^^<xsd:double>;
+  aqm:valor_a_las_2 "00.15"^^<xsd:double>;
+  aqm:valor_a_las_20 "00.14"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00.12"^^<xsd:double>;
+  aqm:valor_a_las_4 "00.09"^^<xsd:double>;
+  aqm:valor_a_las_5 "00.10"^^<xsd:double>;
+  aqm:valor_a_las_6 "00.11"^^<xsd:double>;
+  aqm:valor_a_las_7 "00.12"^^<xsd:double>;
+  aqm:valor_a_las_8 "00.14"^^<xsd:double>;
+  aqm:valor_a_las_9 "00.24"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FHidrocarburos+no+met%C3%A1nicos+%28hexano%29>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079056_6_48> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Carbono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079056";
+  aqm:id_medicion "28079056_6_48";
+  aqm:tecnica "Absorción infrarroja";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.1"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.2"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Carbono>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2025" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+infrarroja> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079056_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079056";
+  aqm:id_medicion "28079056_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00006"^^<xsd:double>;
+  aqm:valor_a_las_10 "00021"^^<xsd:double>;
+  aqm:valor_a_las_11 "00025"^^<xsd:double>;
+  aqm:valor_a_las_12 "00019"^^<xsd:double>;
+  aqm:valor_a_las_13 "00029"^^<xsd:double>;
+  aqm:valor_a_las_14 "00023"^^<xsd:double>;
+  aqm:valor_a_las_15 "00020"^^<xsd:double>;
+  aqm:valor_a_las_16 "00013"^^<xsd:double>;
+  aqm:valor_a_las_17 "00015"^^<xsd:double>;
+  aqm:valor_a_las_18 "00021"^^<xsd:double>;
+  aqm:valor_a_las_19 "00049"^^<xsd:double>;
+  aqm:valor_a_las_2 "00005"^^<xsd:double>;
+  aqm:valor_a_las_20 "00037"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00004"^^<xsd:double>;
+  aqm:valor_a_las_4 "00005"^^<xsd:double>;
+  aqm:valor_a_las_5 "00005"^^<xsd:double>;
+  aqm:valor_a_las_6 "00005"^^<xsd:double>;
+  aqm:valor_a_las_7 "00007"^^<xsd:double>;
+  aqm:valor_a_las_8 "00010"^^<xsd:double>;
+  aqm:valor_a_las_9 "00018"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079056_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079056";
+  aqm:id_medicion "28079056_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00018"^^<xsd:double>;
+  aqm:valor_a_las_10 "00045"^^<xsd:double>;
+  aqm:valor_a_las_11 "00045"^^<xsd:double>;
+  aqm:valor_a_las_12 "00037"^^<xsd:double>;
+  aqm:valor_a_las_13 "00046"^^<xsd:double>;
+  aqm:valor_a_las_14 "00038"^^<xsd:double>;
+  aqm:valor_a_las_15 "00035"^^<xsd:double>;
+  aqm:valor_a_las_16 "00028"^^<xsd:double>;
+  aqm:valor_a_las_17 "00033"^^<xsd:double>;
+  aqm:valor_a_las_18 "00048"^^<xsd:double>;
+  aqm:valor_a_las_19 "00075"^^<xsd:double>;
+  aqm:valor_a_las_2 "00009"^^<xsd:double>;
+  aqm:valor_a_las_20 "00086"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00007"^^<xsd:double>;
+  aqm:valor_a_las_4 "00011"^^<xsd:double>;
+  aqm:valor_a_las_5 "00006"^^<xsd:double>;
+  aqm:valor_a_las_6 "00006"^^<xsd:double>;
+  aqm:valor_a_las_7 "00018"^^<xsd:double>;
+  aqm:valor_a_las_8 "00028"^^<xsd:double>;
+  aqm:valor_a_las_9 "00047"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079056_9_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 2.5 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079056";
+  aqm:id_medicion "28079056_9_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00005"^^<xsd:double>;
+  aqm:valor_a_las_10 "00008"^^<xsd:double>;
+  aqm:valor_a_las_11 "00003"^^<xsd:double>;
+  aqm:valor_a_las_12 "00008"^^<xsd:double>;
+  aqm:valor_a_las_13 "00006"^^<xsd:double>;
+  aqm:valor_a_las_14 "00008"^^<xsd:double>;
+  aqm:valor_a_las_15 "00006"^^<xsd:double>;
+  aqm:valor_a_las_16 "00005"^^<xsd:double>;
+  aqm:valor_a_las_17 "00007"^^<xsd:double>;
+  aqm:valor_a_las_18 "00005"^^<xsd:double>;
+  aqm:valor_a_las_19 "00007"^^<xsd:double>;
+  aqm:valor_a_las_2 "00006"^^<xsd:double>;
+  aqm:valor_a_las_20 "00009"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00010"^^<xsd:double>;
+  aqm:valor_a_las_4 "00007"^^<xsd:double>;
+  aqm:valor_a_las_5 "00007"^^<xsd:double>;
+  aqm:valor_a_las_6 "00003"^^<xsd:double>;
+  aqm:valor_a_las_7 "00002"^^<xsd:double>;
+  aqm:valor_a_las_8 "00003"^^<xsd:double>;
+  aqm:valor_a_las_9 "00006"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+2.5+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Microbalanza> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569";
+  a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079056_10_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 10 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079056";
+  aqm:id_medicion "28079056_10_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00009"^^<xsd:double>;
+  aqm:valor_a_las_10 "00014"^^<xsd:double>;
+  aqm:valor_a_las_11 "00010"^^<xsd:double>;
+  aqm:valor_a_las_12 "00014"^^<xsd:double>;
+  aqm:valor_a_las_13 "00015"^^<xsd:double>;
+  aqm:valor_a_las_14 "00014"^^<xsd:double>;
+  aqm:valor_a_las_15 "00013"^^<xsd:double>;
+  aqm:valor_a_las_16 "00011"^^<xsd:double>;
+  aqm:valor_a_las_17 "00012"^^<xsd:double>;
+  aqm:valor_a_las_18 "00009"^^<xsd:double>;
+  aqm:valor_a_las_19 "00011"^^<xsd:double>;
+  aqm:valor_a_las_2 "00010"^^<xsd:double>;
+  aqm:valor_a_las_20 "00013"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00014"^^<xsd:double>;
+  aqm:valor_a_las_4 "00012"^^<xsd:double>;
+  aqm:valor_a_las_5 "00011"^^<xsd:double>;
+  aqm:valor_a_las_6 "00007"^^<xsd:double>;
+  aqm:valor_a_las_7 "00006"^^<xsd:double>;
+  aqm:valor_a_las_8 "00007"^^<xsd:double>;
+  aqm:valor_a_las_9 "00010"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+10+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079056_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079056";
+  aqm:id_medicion "28079056_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00027"^^<xsd:double>;
+  aqm:valor_a_las_10 "00077"^^<xsd:double>;
+  aqm:valor_a_las_11 "00082"^^<xsd:double>;
+  aqm:valor_a_las_12 "00066"^^<xsd:double>;
+  aqm:valor_a_las_13 "00090"^^<xsd:double>;
+  aqm:valor_a_las_14 "00073"^^<xsd:double>;
+  aqm:valor_a_las_15 "00065"^^<xsd:double>;
+  aqm:valor_a_las_16 "00048"^^<xsd:double>;
+  aqm:valor_a_las_17 "00056"^^<xsd:double>;
+  aqm:valor_a_las_18 "00080"^^<xsd:double>;
+  aqm:valor_a_las_19 "00150"^^<xsd:double>;
+  aqm:valor_a_las_2 "00016"^^<xsd:double>;
+  aqm:valor_a_las_20 "00143"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00013"^^<xsd:double>;
+  aqm:valor_a_las_4 "00019"^^<xsd:double>;
+  aqm:valor_a_las_5 "00013"^^<xsd:double>;
+  aqm:valor_a_las_6 "00014"^^<xsd:double>;
+  aqm:valor_a_las_7 "00029"^^<xsd:double>;
+  aqm:valor_a_las_8 "00044"^^<xsd:double>;
+  aqm:valor_a_las_9 "00075"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079056_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079056";
+  aqm:id_medicion "28079056_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "72.41"^^<xsd:double>;
+  aqm:valor_a_las_10 "37.03"^^<xsd:double>;
+  aqm:valor_a_las_11 "60.42"^^<xsd:double>;
+  aqm:valor_a_las_12 "51.39"^^<xsd:double>;
+  aqm:valor_a_las_13 "51.22"^^<xsd:double>;
+  aqm:valor_a_las_14 "61.22"^^<xsd:double>;
+  aqm:valor_a_las_15 "69.81"^^<xsd:double>;
+  aqm:valor_a_las_16 "80.06"^^<xsd:double>;
+  aqm:valor_a_las_17 "81.02"^^<xsd:double>;
+  aqm:valor_a_las_18 "67.98"^^<xsd:double>;
+  aqm:valor_a_las_19 "52.28"^^<xsd:double>;
+  aqm:valor_a_las_2 "83.32"^^<xsd:double>;
+  aqm:valor_a_las_20 "31.15"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "82.21"^^<xsd:double>;
+  aqm:valor_a_las_4 "74.18"^^<xsd:double>;
+  aqm:valor_a_las_5 "77.36"^^<xsd:double>;
+  aqm:valor_a_las_6 "76.47"^^<xsd:double>;
+  aqm:valor_a_las_7 "64.41"^^<xsd:double>;
+  aqm:valor_a_las_8 "54.20"^^<xsd:double>;
+  aqm:valor_a_las_9 "36.27"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079057_1_38> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Azufre";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079057";
+  aqm:id_medicion "28079057_1_38";
+  aqm:tecnica "Fluorescencia ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00006"^^<xsd:double>;
+  aqm:valor_a_las_10 "00008"^^<xsd:double>;
+  aqm:valor_a_las_11 "00008"^^<xsd:double>;
+  aqm:valor_a_las_12 "00007"^^<xsd:double>;
+  aqm:valor_a_las_13 "00005"^^<xsd:double>;
+  aqm:valor_a_las_14 "00004"^^<xsd:double>;
+  aqm:valor_a_las_15 "00003"^^<xsd:double>;
+  aqm:valor_a_las_16 "00003"^^<xsd:double>;
+  aqm:valor_a_las_17 "00003"^^<xsd:double>;
+  aqm:valor_a_las_18 "00004"^^<xsd:double>;
+  aqm:valor_a_las_19 "00004"^^<xsd:double>;
+  aqm:valor_a_las_2 "00007"^^<xsd:double>;
+  aqm:valor_a_las_20 "00004"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00006"^^<xsd:double>;
+  aqm:valor_a_las_4 "00007"^^<xsd:double>;
+  aqm:valor_a_las_5 "00008"^^<xsd:double>;
+  aqm:valor_a_las_6 "00007"^^<xsd:double>;
+  aqm:valor_a_las_7 "00007"^^<xsd:double>;
+  aqm:valor_a_las_8 "00007"^^<xsd:double>;
+  aqm:valor_a_las_9 "00007"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Azufre> a
+    aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q5282" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FFluorescencia+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q191807" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079057_6_48> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Carbono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079057";
+  aqm:id_medicion "28079057_6_48";
+  aqm:tecnica "Absorción infrarroja";
+  aqm:unidad "mg/m^3";
+  aqm:valor_a_las_1 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_10 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_11 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_12 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_13 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_14 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_15 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_16 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_17 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_18 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_19 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_2 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_20 "000.3"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_4 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_5 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_6 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_7 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_8 "000.2"^^<xsd:double>;
+  aqm:valor_a_las_9 "000.3"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Carbono>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2025" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+infrarroja> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q70906" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079057_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079057";
+  aqm:id_medicion "28079057_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00014"^^<xsd:double>;
+  aqm:valor_a_las_11 "00004"^^<xsd:double>;
+  aqm:valor_a_las_12 "00005"^^<xsd:double>;
+  aqm:valor_a_las_13 "00005"^^<xsd:double>;
+  aqm:valor_a_las_14 "00005"^^<xsd:double>;
+  aqm:valor_a_las_15 "00004"^^<xsd:double>;
+  aqm:valor_a_las_16 "00003"^^<xsd:double>;
+  aqm:valor_a_las_17 "00004"^^<xsd:double>;
+  aqm:valor_a_las_18 "00005"^^<xsd:double>;
+  aqm:valor_a_las_19 "00005"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00007"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00001"^^<xsd:double>;
+  aqm:valor_a_las_8 "00003"^^<xsd:double>;
+  aqm:valor_a_las_9 "00018"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079057_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079057";
+  aqm:id_medicion "28079057_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00006"^^<xsd:double>;
+  aqm:valor_a_las_10 "00050"^^<xsd:double>;
+  aqm:valor_a_las_11 "00013"^^<xsd:double>;
+  aqm:valor_a_las_12 "00017"^^<xsd:double>;
+  aqm:valor_a_las_13 "00014"^^<xsd:double>;
+  aqm:valor_a_las_14 "00012"^^<xsd:double>;
+  aqm:valor_a_las_15 "00012"^^<xsd:double>;
+  aqm:valor_a_las_16 "00010"^^<xsd:double>;
+  aqm:valor_a_las_17 "00011"^^<xsd:double>;
+  aqm:valor_a_las_18 "00014"^^<xsd:double>;
+  aqm:valor_a_las_19 "00017"^^<xsd:double>;
+  aqm:valor_a_las_2 "00005"^^<xsd:double>;
+  aqm:valor_a_las_20 "00027"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00005"^^<xsd:double>;
+  aqm:valor_a_las_4 "00005"^^<xsd:double>;
+  aqm:valor_a_las_5 "00005"^^<xsd:double>;
+  aqm:valor_a_las_6 "00006"^^<xsd:double>;
+  aqm:valor_a_las_7 "00014"^^<xsd:double>;
+  aqm:valor_a_las_8 "00042"^^<xsd:double>;
+  aqm:valor_a_las_9 "00072"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079057_10_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 10 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079057";
+  aqm:id_medicion "28079057_10_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00006"^^<xsd:double>;
+  aqm:valor_a_las_10 "00015"^^<xsd:double>;
+  aqm:valor_a_las_11 "00017"^^<xsd:double>;
+  aqm:valor_a_las_12 "00014"^^<xsd:double>;
+  aqm:valor_a_las_13 "00009"^^<xsd:double>;
+  aqm:valor_a_las_14 "00007"^^<xsd:double>;
+  aqm:valor_a_las_15 "00004"^^<xsd:double>;
+  aqm:valor_a_las_16 "00008"^^<xsd:double>;
+  aqm:valor_a_las_17 "00004"^^<xsd:double>;
+  aqm:valor_a_las_18 "00007"^^<xsd:double>;
+  aqm:valor_a_las_19 "00007"^^<xsd:double>;
+  aqm:valor_a_las_2 "00016"^^<xsd:double>;
+  aqm:valor_a_las_20 "00007"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00013"^^<xsd:double>;
+  aqm:valor_a_las_4 "00009"^^<xsd:double>;
+  aqm:valor_a_las_5 "00006"^^<xsd:double>;
+  aqm:valor_a_las_6 "00006"^^<xsd:double>;
+  aqm:valor_a_las_7 "00005"^^<xsd:double>;
+  aqm:valor_a_las_8 "00008"^^<xsd:double>;
+  aqm:valor_a_las_9 "00012"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+10+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Microbalanza> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079057_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079057";
+  aqm:id_medicion "28079057_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00008"^^<xsd:double>;
+  aqm:valor_a_las_10 "00071"^^<xsd:double>;
+  aqm:valor_a_las_11 "00019"^^<xsd:double>;
+  aqm:valor_a_las_12 "00025"^^<xsd:double>;
+  aqm:valor_a_las_13 "00022"^^<xsd:double>;
+  aqm:valor_a_las_14 "00019"^^<xsd:double>;
+  aqm:valor_a_las_15 "00018"^^<xsd:double>;
+  aqm:valor_a_las_16 "00015"^^<xsd:double>;
+  aqm:valor_a_las_17 "00016"^^<xsd:double>;
+  aqm:valor_a_las_18 "00021"^^<xsd:double>;
+  aqm:valor_a_las_19 "00024"^^<xsd:double>;
+  aqm:valor_a_las_2 "00007"^^<xsd:double>;
+  aqm:valor_a_las_20 "00038"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00006"^^<xsd:double>;
+  aqm:valor_a_las_4 "00006"^^<xsd:double>;
+  aqm:valor_a_las_5 "00006"^^<xsd:double>;
+  aqm:valor_a_las_6 "00007"^^<xsd:double>;
+  aqm:valor_a_las_7 "00015"^^<xsd:double>;
+  aqm:valor_a_las_8 "00047"^^<xsd:double>;
+  aqm:valor_a_las_9 "00099"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079058_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079058";
+  aqm:id_medicion "28079058_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00003"^^<xsd:double>;
+  aqm:valor_a_las_11 "00002"^^<xsd:double>;
+  aqm:valor_a_las_12 "00003"^^<xsd:double>;
+  aqm:valor_a_las_13 "00003"^^<xsd:double>;
+  aqm:valor_a_las_14 "00003"^^<xsd:double>;
+  aqm:valor_a_las_15 "00002"^^<xsd:double>;
+  aqm:valor_a_las_16 "00001"^^<xsd:double>;
+  aqm:valor_a_las_17 "00001"^^<xsd:double>;
+  aqm:valor_a_las_18 "00001"^^<xsd:double>;
+  aqm:valor_a_las_19 "00001"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00001"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00001"^^<xsd:double>;
+  aqm:valor_a_las_8 "00002"^^<xsd:double>;
+  aqm:valor_a_las_9 "00001"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079058_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079058";
+  aqm:id_medicion "28079058_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00004"^^<xsd:double>;
+  aqm:valor_a_las_10 "00021"^^<xsd:double>;
+  aqm:valor_a_las_11 "00011"^^<xsd:double>;
+  aqm:valor_a_las_12 "00016"^^<xsd:double>;
+  aqm:valor_a_las_13 "00013"^^<xsd:double>;
+  aqm:valor_a_las_14 "00014"^^<xsd:double>;
+  aqm:valor_a_las_15 "00014"^^<xsd:double>;
+  aqm:valor_a_las_16 "00007"^^<xsd:double>;
+  aqm:valor_a_las_17 "00005"^^<xsd:double>;
+  aqm:valor_a_las_18 "00005"^^<xsd:double>;
+  aqm:valor_a_las_19 "00007"^^<xsd:double>;
+  aqm:valor_a_las_2 "00003"^^<xsd:double>;
+  aqm:valor_a_las_20 "00010"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00003"^^<xsd:double>;
+  aqm:valor_a_las_4 "00003"^^<xsd:double>;
+  aqm:valor_a_las_5 "00003"^^<xsd:double>;
+  aqm:valor_a_las_6 "00003"^^<xsd:double>;
+  aqm:valor_a_las_7 "00009"^^<xsd:double>;
+  aqm:valor_a_las_8 "00014"^^<xsd:double>;
+  aqm:valor_a_las_9 "00019"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079058_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079058";
+  aqm:id_medicion "28079058_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00005"^^<xsd:double>;
+  aqm:valor_a_las_10 "00025"^^<xsd:double>;
+  aqm:valor_a_las_11 "00013"^^<xsd:double>;
+  aqm:valor_a_las_12 "00021"^^<xsd:double>;
+  aqm:valor_a_las_13 "00017"^^<xsd:double>;
+  aqm:valor_a_las_14 "00018"^^<xsd:double>;
+  aqm:valor_a_las_15 "00017"^^<xsd:double>;
+  aqm:valor_a_las_16 "00009"^^<xsd:double>;
+  aqm:valor_a_las_17 "00006"^^<xsd:double>;
+  aqm:valor_a_las_18 "00007"^^<xsd:double>;
+  aqm:valor_a_las_19 "00008"^^<xsd:double>;
+  aqm:valor_a_las_2 "00004"^^<xsd:double>;
+  aqm:valor_a_las_20 "00011"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00004"^^<xsd:double>;
+  aqm:valor_a_las_4 "00004"^^<xsd:double>;
+  aqm:valor_a_las_5 "00004"^^<xsd:double>;
+  aqm:valor_a_las_6 "00005"^^<xsd:double>;
+  aqm:valor_a_las_7 "00010"^^<xsd:double>;
+  aqm:valor_a_las_8 "00018"^^<xsd:double>;
+  aqm:valor_a_las_9 "00021"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079058_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079058";
+  aqm:id_medicion "28079058_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "86.09"^^<xsd:double>;
+  aqm:valor_a_las_10 "50.13"^^<xsd:double>;
+  aqm:valor_a_las_11 "64.15"^^<xsd:double>;
+  aqm:valor_a_las_12 "64.02"^^<xsd:double>;
+  aqm:valor_a_las_13 "70.21"^^<xsd:double>;
+  aqm:valor_a_las_14 "74.43"^^<xsd:double>;
+  aqm:valor_a_las_15 "80.90"^^<xsd:double>;
+  aqm:valor_a_las_16 "93.27"^^<xsd:double>;
+  aqm:valor_a_las_17 "97.48"^^<xsd:double>;
+  aqm:valor_a_las_18 "92.21"^^<xsd:double>;
+  aqm:valor_a_las_19 "87.13"^^<xsd:double>;
+  aqm:valor_a_las_2 "82.98"^^<xsd:double>;
+  aqm:valor_a_las_20 "79.96"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "79.37"^^<xsd:double>;
+  aqm:valor_a_las_4 "76.97"^^<xsd:double>;
+  aqm:valor_a_las_5 "72.86"^^<xsd:double>;
+  aqm:valor_a_las_6 "73.19"^^<xsd:double>;
+  aqm:valor_a_las_7 "67.77"^^<xsd:double>;
+  aqm:valor_a_las_8 "62.84"^^<xsd:double>;
+  aqm:valor_a_las_9 "52.53"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079059_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079059";
+  aqm:id_medicion "28079059_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00029"^^<xsd:double>;
+  aqm:valor_a_las_11 "00007"^^<xsd:double>;
+  aqm:valor_a_las_12 "00004"^^<xsd:double>;
+  aqm:valor_a_las_13 "00002"^^<xsd:double>;
+  aqm:valor_a_las_14 "00002"^^<xsd:double>;
+  aqm:valor_a_las_15 "00001"^^<xsd:double>;
+  aqm:valor_a_las_16 "00001"^^<xsd:double>;
+  aqm:valor_a_las_17 "00001"^^<xsd:double>;
+  aqm:valor_a_las_18 "00001"^^<xsd:double>;
+  aqm:valor_a_las_19 "00001"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00001"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00001"^^<xsd:double>;
+  aqm:valor_a_las_8 "00003"^^<xsd:double>;
+  aqm:valor_a_las_9 "00007"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079059_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079059";
+  aqm:id_medicion "28079059_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00006"^^<xsd:double>;
+  aqm:valor_a_las_10 "00064"^^<xsd:double>;
+  aqm:valor_a_las_11 "00025"^^<xsd:double>;
+  aqm:valor_a_las_12 "00012"^^<xsd:double>;
+  aqm:valor_a_las_13 "00008"^^<xsd:double>;
+  aqm:valor_a_las_14 "00006"^^<xsd:double>;
+  aqm:valor_a_las_15 "00004"^^<xsd:double>;
+  aqm:valor_a_las_16 "00003"^^<xsd:double>;
+  aqm:valor_a_las_17 "00004"^^<xsd:double>;
+  aqm:valor_a_las_18 "00004"^^<xsd:double>;
+  aqm:valor_a_las_19 "00007"^^<xsd:double>;
+  aqm:valor_a_las_2 "00006"^^<xsd:double>;
+  aqm:valor_a_las_20 "00014"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00004"^^<xsd:double>;
+  aqm:valor_a_las_4 "00005"^^<xsd:double>;
+  aqm:valor_a_las_5 "00006"^^<xsd:double>;
+  aqm:valor_a_las_6 "00006"^^<xsd:double>;
+  aqm:valor_a_las_7 "00014"^^<xsd:double>;
+  aqm:valor_a_las_8 "00038"^^<xsd:double>;
+  aqm:valor_a_las_9 "00058"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079059_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079059";
+  aqm:id_medicion "28079059_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00007"^^<xsd:double>;
+  aqm:valor_a_las_10 "00109"^^<xsd:double>;
+  aqm:valor_a_las_11 "00035"^^<xsd:double>;
+  aqm:valor_a_las_12 "00017"^^<xsd:double>;
+  aqm:valor_a_las_13 "00012"^^<xsd:double>;
+  aqm:valor_a_las_14 "00009"^^<xsd:double>;
+  aqm:valor_a_las_15 "00006"^^<xsd:double>;
+  aqm:valor_a_las_16 "00004"^^<xsd:double>;
+  aqm:valor_a_las_17 "00005"^^<xsd:double>;
+  aqm:valor_a_las_18 "00005"^^<xsd:double>;
+  aqm:valor_a_las_19 "00008"^^<xsd:double>;
+  aqm:valor_a_las_2 "00007"^^<xsd:double>;
+  aqm:valor_a_las_20 "00015"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00006"^^<xsd:double>;
+  aqm:valor_a_las_4 "00006"^^<xsd:double>;
+  aqm:valor_a_las_5 "00008"^^<xsd:double>;
+  aqm:valor_a_las_6 "00007"^^<xsd:double>;
+  aqm:valor_a_las_7 "00015"^^<xsd:double>;
+  aqm:valor_a_las_8 "00043"^^<xsd:double>;
+  aqm:valor_a_las_9 "00069"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079059_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079059";
+  aqm:id_medicion "28079059_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "78.17"^^<xsd:double>;
+  aqm:valor_a_las_10 "18.61"^^<xsd:double>;
+  aqm:valor_a_las_11 "45.85"^^<xsd:double>;
+  aqm:valor_a_las_12 "58.54"^^<xsd:double>;
+  aqm:valor_a_las_13 "66.69"^^<xsd:double>;
+  aqm:valor_a_las_14 "73.07"^^<xsd:double>;
+  aqm:valor_a_las_15 "80.58"^^<xsd:double>;
+  aqm:valor_a_las_16 "83.02"^^<xsd:double>;
+  aqm:valor_a_las_17 "82.41"^^<xsd:double>;
+  aqm:valor_a_las_18 "82.55"^^<xsd:double>;
+  aqm:valor_a_las_19 "78.55"^^<xsd:double>;
+  aqm:valor_a_las_2 "77.64"^^<xsd:double>;
+  aqm:valor_a_las_20 "68.70"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "75.21"^^<xsd:double>;
+  aqm:valor_a_las_4 "72.31"^^<xsd:double>;
+  aqm:valor_a_las_5 "69.49"^^<xsd:double>;
+  aqm:valor_a_las_6 "68.69"^^<xsd:double>;
+  aqm:valor_a_las_7 "63.02"^^<xsd:double>;
+  aqm:valor_a_las_8 "41.00"^^<xsd:double>;
+  aqm:valor_a_las_9 "17.47"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079060_7_8> a aqm:Measurement;
+  aqm:contaminante "Monóxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079060";
+  aqm:id_medicion "28079060_7_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00001"^^<xsd:double>;
+  aqm:valor_a_las_10 "00006"^^<xsd:double>;
+  aqm:valor_a_las_11 "00001"^^<xsd:double>;
+  aqm:valor_a_las_12 "00003"^^<xsd:double>;
+  aqm:valor_a_las_13 "00002"^^<xsd:double>;
+  aqm:valor_a_las_14 "00001"^^<xsd:double>;
+  aqm:valor_a_las_15 "00001"^^<xsd:double>;
+  aqm:valor_a_las_16 "00001"^^<xsd:double>;
+  aqm:valor_a_las_17 "00001"^^<xsd:double>;
+  aqm:valor_a_las_18 "00001"^^<xsd:double>;
+  aqm:valor_a_las_19 "00001"^^<xsd:double>;
+  aqm:valor_a_las_2 "00001"^^<xsd:double>;
+  aqm:valor_a_las_20 "00001"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00001"^^<xsd:double>;
+  aqm:valor_a_las_4 "00001"^^<xsd:double>;
+  aqm:valor_a_las_5 "00001"^^<xsd:double>;
+  aqm:valor_a_las_6 "00001"^^<xsd:double>;
+  aqm:valor_a_las_7 "00001"^^<xsd:double>;
+  aqm:valor_a_las_8 "00002"^^<xsd:double>;
+  aqm:valor_a_las_9 "00006"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FMon%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207843" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079060_8_8> a aqm:Measurement;
+  aqm:contaminante "Dióxido de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079060";
+  aqm:id_medicion "28079060_8_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00009"^^<xsd:double>;
+  aqm:valor_a_las_10 "00017"^^<xsd:double>;
+  aqm:valor_a_las_11 "00009"^^<xsd:double>;
+  aqm:valor_a_las_12 "00014"^^<xsd:double>;
+  aqm:valor_a_las_13 "00013"^^<xsd:double>;
+  aqm:valor_a_las_14 "00009"^^<xsd:double>;
+  aqm:valor_a_las_15 "00008"^^<xsd:double>;
+  aqm:valor_a_las_16 "00008"^^<xsd:double>;
+  aqm:valor_a_las_17 "00009"^^<xsd:double>;
+  aqm:valor_a_las_18 "00009"^^<xsd:double>;
+  aqm:valor_a_las_19 "00010"^^<xsd:double>;
+  aqm:valor_a_las_2 "00009"^^<xsd:double>;
+  aqm:valor_a_las_20 "00014"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00009"^^<xsd:double>;
+  aqm:valor_a_las_4 "00009"^^<xsd:double>;
+  aqm:valor_a_las_5 "00009"^^<xsd:double>;
+  aqm:valor_a_las_6 "00009"^^<xsd:double>;
+  aqm:valor_a_las_7 "00012"^^<xsd:double>;
+  aqm:valor_a_las_8 "00018"^^<xsd:double>;
+  aqm:valor_a_las_9 "00022"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FDi%C3%B3xido+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q207895" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079060_10_47> a aqm:Measurement;
+  aqm:contaminante "Partículas < 10 μm";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079060";
+  aqm:id_medicion "28079060_10_47";
+  aqm:tecnica "Microbalanza";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00009"^^<xsd:double>;
+  aqm:valor_a_las_10 "00011"^^<xsd:double>;
+  aqm:valor_a_las_11 "00011"^^<xsd:double>;
+  aqm:valor_a_las_12 "00011"^^<xsd:double>;
+  aqm:valor_a_las_13 "00005"^^<xsd:double>;
+  aqm:valor_a_las_14 "00004"^^<xsd:double>;
+  aqm:valor_a_las_15 "00003"^^<xsd:double>;
+  aqm:valor_a_las_16 "00002"^^<xsd:double>;
+  aqm:valor_a_las_17 "00003"^^<xsd:double>;
+  aqm:valor_a_las_18 "00006"^^<xsd:double>;
+  aqm:valor_a_las_19 "00010"^^<xsd:double>;
+  aqm:valor_a_las_2 "00010"^^<xsd:double>;
+  aqm:valor_a_las_20 "00009"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00010"^^<xsd:double>;
+  aqm:valor_a_las_4 "00012"^^<xsd:double>;
+  aqm:valor_a_las_5 "00005"^^<xsd:double>;
+  aqm:valor_a_las_6 "00003"^^<xsd:double>;
+  aqm:valor_a_las_7 "00002"^^<xsd:double>;
+  aqm:valor_a_las_8 "00007"^^<xsd:double>;
+  aqm:valor_a_las_9 "00007"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2FPart%C3%ADculas+%3C+10+%CE%BCm>
+  a aqm:Contaminante .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Microbalanza> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q629569" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079060_12_8> a aqm:Measurement;
+  aqm:contaminante "Óxidos de Nitrógeno";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079060";
+  aqm:id_medicion "28079060_12_8";
+  aqm:tecnica "Quimioluminiscencia";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "00010"^^<xsd:double>;
+  aqm:valor_a_las_10 "00027"^^<xsd:double>;
+  aqm:valor_a_las_11 "00011"^^<xsd:double>;
+  aqm:valor_a_las_12 "00019"^^<xsd:double>;
+  aqm:valor_a_las_13 "00015"^^<xsd:double>;
+  aqm:valor_a_las_14 "00011"^^<xsd:double>;
+  aqm:valor_a_las_15 "00010"^^<xsd:double>;
+  aqm:valor_a_las_16 "00009"^^<xsd:double>;
+  aqm:valor_a_las_17 "00010"^^<xsd:double>;
+  aqm:valor_a_las_18 "00011"^^<xsd:double>;
+  aqm:valor_a_las_19 "00011"^^<xsd:double>;
+  aqm:valor_a_las_2 "00010"^^<xsd:double>;
+  aqm:valor_a_las_20 "00016"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "00010"^^<xsd:double>;
+  aqm:valor_a_las_4 "00010"^^<xsd:double>;
+  aqm:valor_a_las_5 "00011"^^<xsd:double>;
+  aqm:valor_a_las_6 "00010"^^<xsd:double>;
+  aqm:valor_a_las_7 "00013"^^<xsd:double>;
+  aqm:valor_a_las_8 "00020"^^<xsd:double>;
+  aqm:valor_a_las_9 "00031"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante%2F%C3%93xidos+de+Nitr%C3%B3geno>
+  a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q424418" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica/Quimioluminiscencia> a aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q2931725" .
+
+<http://www.airQualityMadrid.com/resource/Measurement/28079060_14_6> a aqm:Measurement;
+  aqm:contaminante "Ozono";
+  aqm:fecha "2019-10-2"^^xsd:date;
+  aqm:id_estacion "28079060";
+  aqm:id_medicion "28079060_14_6";
+  aqm:tecnica "Absorción ultravioleta";
+  aqm:unidad "μg/m^3";
+  aqm:valor_a_las_1 "91.40"^^<xsd:double>;
+  aqm:valor_a_las_10 "47.16"^^<xsd:double>;
+  aqm:valor_a_las_11 "70.09"^^<xsd:double>;
+  aqm:valor_a_las_12 "64.99"^^<xsd:double>;
+  aqm:valor_a_las_13 "70.43"^^<xsd:double>;
+  aqm:valor_a_las_14 "86.97"^^<xsd:double>;
+  aqm:valor_a_las_15 "93.07"^^<xsd:double>;
+  aqm:valor_a_las_16 "95.48"^^<xsd:double>;
+  aqm:valor_a_las_17 "93.90"^^<xsd:double>;
+  aqm:valor_a_las_18 "92.00"^^<xsd:double>;
+  aqm:valor_a_las_19 "88.16"^^<xsd:double>;
+  aqm:valor_a_las_2 "89.63"^^<xsd:double>;
+  aqm:valor_a_las_20 "78.43"^^<xsd:double>;
+  aqm:valor_a_las_21 "00000"^^<xsd:double>;
+  aqm:valor_a_las_22 "00000"^^<xsd:double>;
+  aqm:valor_a_las_23 "00000"^^<xsd:double>;
+  aqm:valor_a_las_24 "00000"^^<xsd:double>;
+  aqm:valor_a_las_3 "84.90"^^<xsd:double>;
+  aqm:valor_a_las_4 "80.46"^^<xsd:double>;
+  aqm:valor_a_las_5 "78.29"^^<xsd:double>;
+  aqm:valor_a_las_6 "77.30"^^<xsd:double>;
+  aqm:valor_a_las_7 "69.66"^^<xsd:double>;
+  aqm:valor_a_las_8 "54.47"^^<xsd:double>;
+  aqm:valor_a_las_9 "39.60"^^<xsd:double> .
+
+<http://www.airQualityMadrid.com/resource/Contaminante/Ozono> a aqm:Contaminante;
+  owl:sameAs "https://www.wikidata.org/wiki/Q36933" .
+
+<http://www.airQualityMadrid.com/resource/Tecnica%2FAbsorci%C3%B3n+ultravioleta> a
+    aqm:Tecnica;
+  owl:sameAs "https://www.wikidata.org/wiki/Q332828" .

--- a/HandsOn/Group15/rdf/rdfEstaciones.ttl
+++ b/HandsOn/Group15/rdf/rdfEstaciones.ttl
@@ -1,3 +1,4 @@
+@prefix geo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace#> .
@@ -9,191 +10,191 @@
 <http://www.airQualityMadrid.com/resource/Station/28079004> a aqm:Station;
   aqm:direccion "Plaza de España";
   aqm:id_estacion "28079004"^^xsd:int;
-  aqm:latitud "40.4238823"^^<xsd:float>;
-  aqm:longitud "-3.7122567"^^<xsd:float>;
   aqm:nombre "Pza. de España";
-  aqm:tipo "Urbana tráfico" .
+  aqm:tipo "Urbana tráfico";
+  geo:lat "40.4238823"^^<xsd:float>;
+  geo:long "-3.7122567"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079008> a aqm:Station;
   aqm:direccion "Entre C/ Alcalá y C/ O’ Donell ";
   aqm:id_estacion "28079008"^^xsd:int;
-  aqm:latitud "40.4215533"^^<xsd:float>;
-  aqm:longitud "-3.6823158"^^<xsd:float>;
   aqm:nombre "Escuelas Aguirre";
-  aqm:tipo "Urbana tráfico" .
+  aqm:tipo "Urbana tráfico";
+  geo:lat "40.4215533"^^<xsd:float>;
+  geo:long "-3.6823158"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079011> a aqm:Station;
   aqm:direccion "Avda. Ramón y Cajal  esq. C/ Príncipe de Vergara";
   aqm:id_estacion "28079011"^^xsd:int;
-  aqm:latitud "40.4514734"^^<xsd:float>;
-  aqm:longitud "-3.6773491"^^<xsd:float>;
   aqm:nombre "Avda. Ramón y Cajal";
-  aqm:tipo "Urbana tráfico" .
+  aqm:tipo "Urbana tráfico";
+  geo:lat "40.4514734"^^<xsd:float>;
+  geo:long "-3.6773491"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079016> a aqm:Station;
   aqm:direccion "C/ Arturo Soria  esq. C/  Vizconde de los Asilos ";
   aqm:id_estacion "28079016"^^xsd:int;
-  aqm:latitud "40.4400457"^^<xsd:float>;
-  aqm:longitud "-3.6392422"^^<xsd:float>;
   aqm:nombre "Arturo Soria";
-  aqm:tipo "Urbana fondo" .
+  aqm:tipo "Urbana fondo";
+  geo:lat "40.4400457"^^<xsd:float>;
+  geo:long "-3.6392422"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079017> a aqm:Station;
   aqm:direccion "C/. Juan Peñalver";
   aqm:id_estacion "28079017"^^xsd:int;
-  aqm:latitud "40.347147"^^<xsd:float>;
-  aqm:longitud "-3.7133167"^^<xsd:float>;
   aqm:nombre "Villaverde";
-  aqm:tipo "Urbana fondo" .
+  aqm:tipo "Urbana fondo";
+  geo:lat "40.347147"^^<xsd:float>;
+  geo:long "-3.7133167"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079018> a aqm:Station;
   aqm:direccion "Calle Farolillo - C/Ervigio";
   aqm:id_estacion "28079018"^^xsd:int;
-  aqm:latitud "40.3947825"^^<xsd:float>;
-  aqm:longitud "-3.7318356"^^<xsd:float>;
   aqm:nombre "Farolillo";
-  aqm:tipo "Urbana fondo" .
+  aqm:tipo "Urbana fondo";
+  geo:lat "40.3947825"^^<xsd:float>;
+  geo:long "-3.7318356"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079024> a aqm:Station;
   aqm:direccion "Casa de Campo  (Terminal del Teleférico)";
   aqm:id_estacion "28079024"^^xsd:int;
-  aqm:latitud "40.4193577"^^<xsd:float>;
-  aqm:longitud "-3.7473445"^^<xsd:float>;
   aqm:nombre "Casa de Campo";
-  aqm:tipo "Suburbana" .
+  aqm:tipo "Suburbana";
+  geo:lat "40.4193577"^^<xsd:float>;
+  geo:long "-3.7473445"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079027> a aqm:Station;
   aqm:direccion "C/. Júpiter, 21 (Barajas) ";
   aqm:id_estacion "28079027"^^xsd:int;
-  aqm:latitud "40.4769179"^^<xsd:float>;
-  aqm:longitud "-3.5800258"^^<xsd:float>;
   aqm:nombre "Barajas Pueblo";
-  aqm:tipo "Urbana fondo" .
+  aqm:tipo "Urbana fondo";
+  geo:lat "40.4769179"^^<xsd:float>;
+  geo:long "-3.5800258"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079035> a aqm:Station;
   aqm:direccion "Plaza del Carmen esq. Tres Cruces. ";
   aqm:id_estacion "28079035"^^xsd:int;
-  aqm:latitud "40.4192091"^^<xsd:float>;
-  aqm:longitud "-3.7031662"^^<xsd:float>;
   aqm:nombre "Pza. del Carmen";
-  aqm:tipo "Urbana fondo" .
+  aqm:tipo "Urbana fondo";
+  geo:lat "40.4192091"^^<xsd:float>;
+  geo:long "-3.7031662"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079036> a aqm:Station;
   aqm:direccion "Avd. Moratalaz  esq. Camino de los Vinateros";
   aqm:id_estacion "28079036"^^xsd:int;
-  aqm:latitud "40.4079517"^^<xsd:float>;
-  aqm:longitud "-3.6453104"^^<xsd:float>;
   aqm:nombre "Moratalaz";
-  aqm:tipo "Urbana tráfico" .
+  aqm:tipo "Urbana tráfico";
+  geo:lat "40.4079517"^^<xsd:float>;
+  geo:long "-3.6453104"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079038> a aqm:Station;
   aqm:direccion "Avda. Pablo Iglesias esq. C/ Marqués de Lema";
   aqm:id_estacion "28079038"^^xsd:int;
-  aqm:latitud "40.4455439"^^<xsd:float>;
-  aqm:longitud "-3.7071303"^^<xsd:float>;
   aqm:nombre "Cuatro Caminos";
-  aqm:tipo "Urbana tráfico" .
+  aqm:tipo "Urbana tráfico";
+  geo:lat "40.4455439"^^<xsd:float>;
+  geo:long "-3.7071303"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079039> a aqm:Station;
   aqm:direccion "Avd. Betanzos esq. C/  Monforte de Lemos ";
   aqm:id_estacion "28079039"^^xsd:int;
-  aqm:latitud "40.4782322"^^<xsd:float>;
-  aqm:longitud "-3.7115364"^^<xsd:float>;
   aqm:nombre "Barrio del Pilar";
-  aqm:tipo "Urbana tráfico" .
+  aqm:tipo "Urbana tráfico";
+  geo:lat "40.4782322"^^<xsd:float>;
+  geo:long "-3.7115364"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079040> a aqm:Station;
   aqm:direccion "C/ Arroyo del Olivar  esq. C/  Río Grande. ";
   aqm:id_estacion "28079040"^^xsd:int;
-  aqm:latitud "40.3881478"^^<xsd:float>;
-  aqm:longitud "-3.6515286"^^<xsd:float>;
   aqm:nombre "Vallecas";
-  aqm:tipo "Urbana fondo" .
+  aqm:tipo "Urbana fondo";
+  geo:lat "40.3881478"^^<xsd:float>;
+  geo:long "-3.6515286"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079047> a aqm:Station;
   aqm:direccion "C/ Juan de Mariana / Pza. Amanecer Mendez Alvaro";
   aqm:id_estacion "28079047"^^xsd:int;
-  aqm:latitud "40.3980991"^^<xsd:float>;
-  aqm:longitud "-3.6868138"^^<xsd:float>;
   aqm:nombre "Mendez Alvaro";
-  aqm:tipo "Urbana fondo" .
+  aqm:tipo "Urbana fondo";
+  geo:lat "40.3980991"^^<xsd:float>;
+  geo:long "-3.6868138"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079048> a aqm:Station;
   aqm:direccion "C/ Jose Gutierrez Abascal";
   aqm:id_estacion "28079048"^^xsd:int;
-  aqm:latitud "40.4398904"^^<xsd:float>;
-  aqm:longitud "-3.6903729"^^<xsd:float>;
   aqm:nombre "Castellana";
-  aqm:tipo "Urbana tráfico" .
+  aqm:tipo "Urbana tráfico";
+  geo:lat "40.4398904"^^<xsd:float>;
+  geo:long "-3.6903729"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079049> a aqm:Station;
   aqm:direccion "Paseo Venezuela- Casa de Vacas";
   aqm:id_estacion "28079049"^^xsd:int;
-  aqm:latitud "40.41444444444440"^^<xsd:float>;
-  aqm:longitud "-3.6824999999999900"^^<xsd:float>;
   aqm:nombre "Parque del Retiro";
-  aqm:tipo "Urbana fondo" .
+  aqm:tipo "Urbana fondo";
+  geo:lat "40.41444444444440"^^<xsd:float>;
+  geo:long "-3.6824999999999900"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079050> a aqm:Station;
   aqm:direccion "Plaza Castilla (Canal)";
   aqm:id_estacion "28079050"^^xsd:int;
-  aqm:latitud "40.4655841"^^<xsd:float>;
-  aqm:longitud "-3.6887449"^^<xsd:float>;
   aqm:nombre "Plaza Castilla";
-  aqm:tipo "Urbana tráfico" .
+  aqm:tipo "Urbana tráfico";
+  geo:lat "40.4655841"^^<xsd:float>;
+  geo:long "-3.6887449"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079054> a aqm:Station;
   aqm:direccion "Avda La Gavia / Avda. Las Suertes";
   aqm:id_estacion "28079054"^^xsd:int;
-  aqm:latitud "40.3730118"^^<xsd:float>;
-  aqm:longitud "-3.6121394"^^<xsd:float>;
   aqm:nombre "Ensanche de Vallecas";
-  aqm:tipo "Urbana fondo" .
+  aqm:tipo "Urbana fondo";
+  geo:lat "40.3730118"^^<xsd:float>;
+  geo:long "-3.6121394"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079055> a aqm:Station;
   aqm:direccion "C/ Riaño (Barajas) ";
   aqm:id_estacion "28079055"^^xsd:int;
-  aqm:latitud "40.4623628"^^<xsd:float>;
-  aqm:longitud "-3.5805649"^^<xsd:float>;
   aqm:nombre "Urb. Embajada";
-  aqm:tipo "Urbana fondo" .
+  aqm:tipo "Urbana fondo";
+  geo:lat "40.4623628"^^<xsd:float>;
+  geo:long "-3.5805649"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079056> a aqm:Station;
   aqm:direccion " Pza. Elíptica - Avda. Oporto";
   aqm:id_estacion "28079056"^^xsd:int;
-  aqm:latitud "40.3850336"^^<xsd:float>;
-  aqm:longitud "-3.7187679"^^<xsd:float>;
   aqm:nombre "Pza. Elíptica";
-  aqm:tipo "Urbana tráfico" .
+  aqm:tipo "Urbana tráfico";
+  geo:lat "40.3850336"^^<xsd:float>;
+  geo:long "-3.7187679"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079057> a aqm:Station;
   aqm:direccion "C/ Princesa de Eboli esq C/ Maria Tudor";
   aqm:id_estacion "28079057"^^xsd:int;
-  aqm:latitud "40.4942012"^^<xsd:float>;
-  aqm:longitud "-3.6605173"^^<xsd:float>;
   aqm:nombre "Sanchinarro";
-  aqm:tipo "Urbana fondo" .
+  aqm:tipo "Urbana fondo";
+  geo:lat "40.4942012"^^<xsd:float>;
+  geo:long "-3.6605173"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079058> a aqm:Station;
   aqm:direccion "Avda. La Guardia";
   aqm:id_estacion "28079058"^^xsd:int;
-  aqm:latitud "40.5180701"^^<xsd:float>;
-  aqm:longitud "-3.7746101"^^<xsd:float>;
   aqm:nombre "El Pardo";
-  aqm:tipo "Suburbana" .
+  aqm:tipo "Suburbana";
+  geo:lat "40.5180701"^^<xsd:float>;
+  geo:long "-3.7746101"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079059> a aqm:Station;
   aqm:direccion "Parque Juan Carlos I (frente oficinas mantenimiento)";
   aqm:id_estacion "28079059"^^xsd:int;
-  aqm:latitud "40.4607255"^^<xsd:float>;
-  aqm:longitud "-3.6163407"^^<xsd:float>;
   aqm:nombre "Juan Carlos I";
-  aqm:tipo "Suburbana" .
+  aqm:tipo "Suburbana";
+  geo:lat "40.4607255"^^<xsd:float>;
+  geo:long "-3.6163407"^^<xsd:float> .
 
 <http://www.airQualityMadrid.com/resource/Station/28079060> a aqm:Station;
   aqm:direccion "Plaza Tres Olivos ";
   aqm:id_estacion "28079060"^^xsd:int;
-  aqm:latitud "40.5005477"^^<xsd:float>;
-  aqm:longitud "-3.6897308"^^<xsd:float>;
   aqm:nombre "Tres Olivos";
-  aqm:tipo "Urbana fondo" .
+  aqm:tipo "Urbana fondo";
+  geo:lat "40.5005477"^^<xsd:float>;
+  geo:long "-3.6897308"^^<xsd:float> .


### PR DESCRIPTION
Sobre el último pull request: 

There are other class and properties that are frequently used and that can be reused from other ontologies or vocabularies. -> Hecho, tras analizar nuestros datasets, hemos visto que las propiedades "lagitud" y "longitud" de la clase "Station" pueden ser sustituidos por la reutilización de dichas propiedades (esto supone un cambio en la ontología).

Se barajó reutilizar completamente el vocabulario sosa (https://www.w3.org/TR/vocab-ssn/) que se utiliza para expresar sensores, mediciones y propiedades observadas en las mediciones, pero su esquema de UN sensor UNA medicion UNA propiedad no encaja al 100% con los requisitos de nuestra app así que decidimos seguir con lo nuestro, ya que de lo contrario la complejidad en el código subiría demasiado sin necesidad.

Sobre en HandsOn4, identificamos que nuestras propie "Contaminante" y "Tecnica" (del dataset rdfDatosEstaciones) podian ser linkeadas a los datasets de Wikidata "Chemical Compound" y "Chemical processes", respectivamente. Se hizo un servicio de reconciliación con ambos.